### PR TITLE
Get rid of BOM character, also more

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,16 +1,15 @@
-﻿<!DOCTYPE HTML>
+<!DOCTYPE html>
 <html lang="en">
 
 <head>
 <meta http-equiv="Content-Type" content="text/html;charset=utf-8">
 <meta name="keywords" content="muck, mush, mux, moo, client, mu client, mu* client, beip, beipmu, online games ">
 <meta name="description" content="BeipMU is a compact, easy-to-use MUCKing client.">
-<meta name="GENERATOR" content="Notepad">
 <link rel="stylesheet" href="style.css">
 <link href="https://fonts.googleapis.com/css?family=Encode+Sans+Condensed%7CRoboto" rel="stylesheet">
 <title>BeipMU</title>
 </head>
-<BODY>
+<body>
 
 <h1><img src="images/beipbutton.gif" alt="BeipMU"> BeipMU!</h1>
 <p>
@@ -78,7 +77,7 @@ or could be improved please let us know!
   <td>
    <h2>Some of our fancier features:</h2>
    <ul>
-    <li><a href="Screenshots/Fancy.png">Mix & Match Fonts & Styles</a></li>
+    <li><a href="Screenshots/Fancy.png">Mix &amp; Match Fonts &amp; Styles</a></li>
     <li><a href="Screenshots/PennMush.png">IPv6</a></li>
     <li>High DPI support (4K monitors, etc)</li>
     <li>Smooth scrolling (optional of course)</li>
@@ -118,7 +117,7 @@ or could be improved please let us know!
     <li><a href="Screenshots/Triggers.png">Trigger Dialog</a></li>
     <li><a href="Screenshots/Macros.png">Macros Dialog</a></li>
     <li><a href="Screenshots/Aliases.png">Aliases Dialog</a></li>
-    <li><a href="Screenshots/BeipUx.jpg">Running under Linux & Wine - Old screenshot, but if this stops working just ask!</a></li>
+    <li><a href="Screenshots/BeipUx.jpg">Running under Linux &amp; Wine - Old screenshot, but if this stops working just ask!</a></li>
    </ul>
   </td>
   <td>
@@ -143,7 +142,7 @@ run a script, or even write a chat server? Good news! If you're interested in he
 <p>
   <br>
   <a href="https://validator.w3.org/check?uri=referer"><img
-    src="https://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01 Strict" height="31" width="88"></a> Thanks to Theo
+    src="https://www.w3.org/Icons/valid-html401" alt="Valid HTML 4.01 Strict" height="31" width="88"></a>
 </p>
-</BODY>
-</HTML>
+</body>
+</html>


### PR DESCRIPTION
Also make some changes to capitalization to make things more consistent (and more easily checked as XHTML).  Also did switch those & to &amp; :P
And while generator=notepad is cute, technically it's not meant to be used for text-editors or human-written docs. :P  But you can add that line back if you want.
Got rid of my name.  The entire valid HTML button could be removed since the page is HTML5 rather than 4.01 Strict now.