### PR TITLE
Add input & output window styles

### DIFF
--- a/src/Dlg_InputWindow.cpp
+++ b/src/Dlg_InputWindow.cpp
@@ -296,10 +296,7 @@ LRESULT Dlg_InputWindow::On(const Msg::Command &msg)
    {
       case IDOK:
          Save(*m_ppropInputWindow);
-         if(m_ppropInputWindow==&GlobalInputSettings() || m_input_window.IsPrimary())
-            OnGlobalInputSettingsModified(*m_ppropInputWindow); // Update them all through an event
-         else
-            m_input_window.ApplyProps();
+         OnGlobalInputSettingsModified(*m_ppropInputWindow);
       case IDCANCEL:
          Close();
          break;

--- a/src/Dlg_TextWindow.cpp
+++ b/src/Dlg_TextWindow.cpp
@@ -6,7 +6,7 @@ void SetTextWindowProperties(Text::Wnd &window, Prop::TextWindow &prop);
 
 struct Dlg_TextWindow : Wnd_Dialog
 {
-   Dlg_TextWindow(Window wndParent, Text::Wnd &text_window, Prop::TextWindow &propTextWindow);
+   Dlg_TextWindow(Window wndParent, Prop::TextWindow &propTextWindow);
 
 private:
 
@@ -59,7 +59,6 @@ private:
 
    AL::Button *mp_button_copy_settings, *mp_button_paste_settings;
 
-   Text::Wnd &m_text_window;
    CntPtrTo<Prop::TextWindow> m_ppropTextWindow;
    Prop::Font m_propFont;
    Color m_clrFG, m_clrBG, m_clrLink; // Local copies (in case of cancel!)
@@ -73,9 +72,8 @@ LRESULT Dlg_TextWindow::WndProc(const Message &msg)
    return Dispatch<Wnd_Dialog, Msg::Create, Msg::Command, Msg::Paint>(msg);
 }
 
-Dlg_TextWindow::Dlg_TextWindow(Window wndParent, Text::Wnd &text_window, Prop::TextWindow &propTextWindow)
- : m_text_window{text_window},
-   m_ppropTextWindow{&propTextWindow}
+Dlg_TextWindow::Dlg_TextWindow(Window wndParent, Prop::TextWindow &propTextWindow)
+ : m_ppropTextWindow{&propTextWindow}
 {
    FixedStringBuilder<256> title;
    if(&propTextWindow==&GlobalTextSettings())
@@ -422,10 +420,7 @@ LRESULT Dlg_TextWindow::On(const Msg::Command &msg)
       case IDOK:
          Save(*m_ppropTextWindow);
          Global_PropChange(); // To handle the selection message/new content global settings
-         if(m_ppropTextWindow==&GlobalTextSettings())
-            OnGlobalTextSettingsModified(); // Update them all through an event
-         else
-            ::SetTextWindowProperties(m_text_window, *m_ppropTextWindow);
+         OnGlobalTextSettingsModified(*m_ppropTextWindow); // Update them all through an event
       case IDCANCEL:
          Close();
          break;
@@ -493,7 +488,7 @@ LRESULT Dlg_TextWindow::On(const Msg::Paint &msg)
    return msg.Success();
 }
 
-void CreateDialog_TextWindow(Window wndParent, Text::Wnd &text_window, Prop::TextWindow &propTextWindow)
+void CreateDialog_TextWindow(Window wndParent, Prop::TextWindow &propTextWindow)
 {
-   new Dlg_TextWindow(wndParent, text_window, propTextWindow);
+   new Dlg_TextWindow(wndParent, propTextWindow);
 }

--- a/src/Main.h
+++ b/src/Main.h
@@ -119,14 +119,13 @@ void ResetConfig();
 
 Prop::Global &GetSampleConfig();
 
-struct GlobalTextSettingsModified { };
+struct GlobalTextSettingsModified { Prop::TextWindow &prop; };
 struct GlobalInputSettingsModified { Prop::InputWindow &prop; };
 extern Events::SendersOf<GlobalTextSettingsModified, GlobalInputSettingsModified> g_text_events;
 
 Prop::TextWindow &GlobalTextSettings();
-void OnGlobalTextSettingsModified(); // Called by the text dialog when changing global settings
 Prop::InputWindow &GlobalInputSettings();
-void OnGlobalInputSettingsModified(Prop::InputWindow &prop); // Called by the input dialog when settings
+void OnGlobalTextSettingsModified(Prop::TextWindow &prop); // Called by the text dialog when changing settings
 
 void CreateDialog_KeyboardMacros(Window wnd, Prop::Server *ppropServer, Prop::Character *ppropCharacter);
 void CloseDialog_KeyboardMacros();

--- a/src/OM.idl
+++ b/src/OM.idl
@@ -361,6 +361,7 @@ library BeipMU
       // OnGMCP(BSTR package, BSTR json)
 
       HRESULT ProcessAliases([in] BSTR text, [out, retval] BSTR *result);
+      HRESULT AddToInputHistory([in] BSTR text);
    }
 
    [ uuid(4703fc42-40af-4b8a-94f2-e09dff9ab8e0) ]

--- a/src/Root.prp
+++ b/src/Root.prp
@@ -218,7 +218,6 @@ Prop WebViewWindow
 {
     String URL
     String ID
-    Flag HostObjects=true
 }
 
 Prop DockedWindow

--- a/src/WebView.cpp
+++ b/src/WebView.cpp
@@ -386,12 +386,15 @@ Wnd_WebView::Wnd_WebView(Wnd_Main &wnd_main, ConstString id)
 	Create("WebView", WS_OVERLAPPEDWINDOW, Window::Position(int2(CW_USEDEFAULT, CW_USEDEFAULT), int2(800, 800)), wnd_main, WS_EX_APPWINDOW);
 	mp_docking=&m_wnd_main.CreateDocking(*this);
 	Show(SW_SHOWNOACTIVATE);
+
+	AttachTo<GlobalInputSettingsModified>(g_text_events);
+	AttachTo<GlobalTextSettingsModified>(g_text_events);
 }
 
 LRESULT Wnd_WebView::On(const Msg::Create &msg)
 {
 	if(!WebView2EnvironmentCreator::sp_instance)
-			MakeCounting<WebView2EnvironmentCreator>();
+		MakeCounting<WebView2EnvironmentCreator>();
 
 	if(!gp_environment)
 		AttachTo<Event_WebViewEnvironmentCreated>(*WebView2EnvironmentCreator::sp_instance);
@@ -409,8 +412,8 @@ void Wnd_WebView::On(const Event_WebViewEnvironmentCreated &)
 			if(FAILED(result) || !p_controller)
 				return S_OK; // Window closed?
 
-			mp_webviewController = p_controller;
-			mp_webviewController->get_CoreWebView2(mp_webview.Address());
+			mp_webview_controller = p_controller;
+			mp_webview_controller->get_CoreWebView2(mp_webview.Address());
  
 			// Add a few settings for the webview
 			// The demo step is redundant since the values are the default settings
@@ -428,8 +431,8 @@ void Wnd_WebView::On(const Event_WebViewEnvironmentCreated &)
 #endif
 
 			// Resize WebView to fit the bounds of the parent window
-			mp_webviewController->put_Bounds(ToRECT(ClientRect()));
-			mp_webviewController->put_IsVisible(TRUE);
+			mp_webview_controller->put_Bounds(ToRECT(ClientRect()));
+			mp_webview_controller->put_IsVisible(TRUE);
 
 			Automation::GetApp(); // Must do this so that OM_Help initializes properly
 #if 0
@@ -481,30 +484,57 @@ void Wnd_WebView::On(const Event_WebViewEnvironmentCreated &)
 
 			mp_webview->add_NavigationCompleted(Microsoft::WRL::Callback<ICoreWebView2NavigationCompletedEventHandler>(
 				[this](ICoreWebView2 *webview, ICoreWebView2NavigationCompletedEventArgs *args) -> HRESULT {
-					auto &input_props = m_wnd_main.GetInputWindow().GetProps();
-					auto &output_props = m_wnd_main.GetOutputProps();
-					HybridStringBuilder<1024> script(
-						"var style = document.createElement('style');"
-						"style.innerHTML = `"
-						".clientOutput { background:", HTML::HTMLColor(output_props.clrBack()),
-						"; color:", HTML::HTMLColor(output_props.clrFore()),
-						"; font-family:'", output_props.propFont().pclName(), "'; font-size:", output_props.propFont().Size(), "px; }\n"
-						".clientInput { background:", HTML::HTMLColor(input_props.clrBack()),
-						"; color:", HTML::HTMLColor(input_props.clrFore()),
-						"; font-family:'", input_props.propFont().pclName(), "'; font-size:", input_props.propFont().Size(), "px; }\n"
-						"`;"
-						"document.head.appendChild(style);"
-					);
-					mp_webview->ExecuteScript(UTF16(script).stringz(), nullptr);
+					SetStyles();
 					return S_OK;
 				}).Get(), &token);
-
 
 			if(m_url || m_source)
 				Navigate();
 
 			return S_OK;
 					}).Get());
+}
+
+void Wnd_WebView::On(const GlobalTextSettingsModified &event)
+{
+	SetStyles();
+}
+
+void Wnd_WebView::On(const GlobalInputSettingsModified &)
+{
+	SetStyles();
+}
+
+void Wnd_WebView::SetStyles()
+{
+	if(!mp_webview)
+		return;
+
+	auto &input_props = m_wnd_main.GetInputWindow().GetProps();
+	auto &output_props = m_wnd_main.GetOutputProps();
+	HybridStringBuilder<1024> script(
+		"{ const styleId = 'clientInputOutputStyleVars';"
+		"var style = document.getElementById(styleId);"
+		"if (style === null) {"
+		" style = document.createElement('style');"
+		" style.id = styleId;"
+		" document.head.appendChild(style);"
+		" style = document.getElementById(styleId);"
+		"}"
+		"style.innerHTML = `"
+		":root {"
+		" \n --client-output-background:", HTML::HTMLColor(output_props.clrBack()),
+		";\n --client-output-foreground:", HTML::HTMLColor(output_props.clrFore()),
+		";\n --client-output-font:'", output_props.propFont().pclName(), "'"
+		";\n --client-output-font-size:", output_props.propFont().Size(), "px"
+		";\n --client-input-background:", HTML::HTMLColor(input_props.clrBack()),
+		";\n --client-input-foreground:", HTML::HTMLColor(input_props.clrFore()),
+		";\n --client-input-font:'", input_props.propFont().pclName(), "'"
+		";\n --client-input-font-size:", input_props.propFont().Size(), "px"
+		";\n}"
+		"`; }"
+	);
+	mp_webview->ExecuteScript(UTF16(script).stringz(), nullptr);
 }
 
 void Wnd_WebView::SetURL(ConstString url, Array<Header> headers)
@@ -538,12 +568,12 @@ void Wnd_WebView::Navigate()
 
 LRESULT Wnd_WebView::On(const Msg::WindowPosChanged &msg)
 {
-	if(mp_webviewController)
+	if(mp_webview_controller)
 	{
 		if(msg.WasResized())
-			mp_webviewController->put_Bounds(ToRECT(ClientRect()));
+			mp_webview_controller->put_Bounds(ToRECT(ClientRect()));
 		if(msg.WasMoved())
-			mp_webviewController->NotifyParentWindowPositionChanged();
+			mp_webview_controller->NotifyParentWindowPositionChanged();
 	}
 
 	return msg.Success();

--- a/src/WebView.cpp
+++ b/src/WebView.cpp
@@ -476,27 +476,29 @@ void Wnd_WebView::On(const Event_WebViewEnvironmentCreated &)
 
 					OM::Variant v_client{mp_webview_om};
 					mp_webview->AddHostObjectToScript(L"client", &v_client);
-
-					{
-						auto &input_props = m_wnd_main.GetInputWindow().GetProps();
-						auto &output_props = m_wnd_main.GetOutputProps();
-						HybridStringBuilder<1024> script(
-							"var style = document.createElement('style');"
-							"style.innerHTML = `"
-							".clientOutput { background:", HTML::HTMLColor(output_props.clrBack()),
-							"; color:", HTML::HTMLColor(output_props.clrFore()),
-							"; font-family:'", output_props.propFont().pclName(), "'; font-size:", output_props.propFont().Size(), "px; }\n"
-							".clientInput { background:", HTML::HTMLColor(input_props.clrBack()),
-							"; color:", HTML::HTMLColor(input_props.clrFore()),
-							"; font-family:'", input_props.propFont().pclName(), "'; font-size:", input_props.propFont().Size(), "px; }\n"
-							"`;"
-							"document.head.appendChild(style);"
-						);
-						mp_webview->ExecuteScript(UTF16(script).stringz(), nullptr);
-					}
-
 					return S_OK;
 				}).Get(), &token);
+
+			mp_webview->add_NavigationCompleted(Microsoft::WRL::Callback<ICoreWebView2NavigationCompletedEventHandler>(
+				[this](ICoreWebView2 *webview, ICoreWebView2NavigationCompletedEventArgs *args) -> HRESULT {
+					auto &input_props = m_wnd_main.GetInputWindow().GetProps();
+					auto &output_props = m_wnd_main.GetOutputProps();
+					HybridStringBuilder<1024> script(
+						"var style = document.createElement('style');"
+						"style.innerHTML = `"
+						".clientOutput { background:", HTML::HTMLColor(output_props.clrBack()),
+						"; color:", HTML::HTMLColor(output_props.clrFore()),
+						"; font-family:'", output_props.propFont().pclName(), "'; font-size:", output_props.propFont().Size(), "px; }\n"
+						".clientInput { background:", HTML::HTMLColor(input_props.clrBack()),
+						"; color:", HTML::HTMLColor(input_props.clrFore()),
+						"; font-family:'", input_props.propFont().pclName(), "'; font-size:", input_props.propFont().Size(), "px; }\n"
+						"`;"
+						"document.head.appendChild(style);"
+					);
+					mp_webview->ExecuteScript(UTF16(script).stringz(), nullptr);
+					return S_OK;
+				}).Get(), &token);
+
 
 			if(m_url || m_source)
 				Navigate();

--- a/src/WebView.h
+++ b/src/WebView.h
@@ -9,7 +9,7 @@ struct Wnd_WebView
  : DLNode<Wnd_WebView>, 
 	TWindowImpl<Wnd_WebView>,
 	Events::Sends_Deleted,
-	Events::ReceiversOf<Wnd_WebView, Event_WebViewEnvironmentCreated>
+	Events::ReceiversOf<Wnd_WebView, Event_WebViewEnvironmentCreated, GlobalTextSettingsModified, GlobalInputSettingsModified>
 {
 	struct Header
 	{
@@ -23,15 +23,17 @@ struct Wnd_WebView
 	void SetURL(ConstString url, Array<Header> headers={});
 	void SetSource(ConstString source);
 
-	ConstString GetID() const { return m_id; }
+	void SetStyles();
 
-	bool HostObjects() const { return m_host_objects; }
+	ConstString GetID() const { return m_id; }
 
 	Wnd_Docking &GetDocking() const { return *mp_docking; }
 	Wnd_Main &GetWndMain() const { return m_wnd_main; }
 
 	void On(const Event_WebViewEnvironmentCreated &);
 	void On(const Event_WebViewCreated &);
+	void On(const GlobalTextSettingsModified &);
+	void On(const GlobalInputSettingsModified &);
 
 private:
 
@@ -52,7 +54,7 @@ private:
 
 	Collection<Header> m_headers;
 
-	CntPtrTo<ICoreWebView2Controller> mp_webviewController;
+	CntPtrTo<ICoreWebView2Controller> mp_webview_controller;
 	CntPtrTo<ICoreWebView2> mp_webview;
 	Wnd_Docking *mp_docking;
 	CntPtrTo<WebView_OM> mp_webview_om;

--- a/src/Wnd_Input.cpp
+++ b/src/Wnd_Input.cpp
@@ -1042,7 +1042,7 @@ Wnd_InputPane::~Wnd_InputPane()
 
 void Wnd_InputPane::On(const GlobalInputSettingsModified &event)
 {
-   if(&m_input.GetProps()==&GlobalInputSettings())
+   if(&m_input.GetProps()==&event.prop)
       m_input.ApplyProps();
 }
 

--- a/src/Wnd_Main.cpp
+++ b/src/Wnd_Main.cpp
@@ -32,7 +32,7 @@ Prop::Docking g_propDockingClipboard;
 static CntPtrTo<Prop::MainWindowSettings> g_ppropMainWindowSettingsClipboard=MakeCounting<Prop::MainWindowSettings>();
 
 void SetBadgeNumber(int num);
-void CreateDialog_TextWindow(Window wndParent, Text::Wnd &text_window, Prop::TextWindow &propTextWindow);
+void CreateDialog_TextWindow(Window wndParent, Prop::TextWindow &propTextWindow);
 void CreateDialog_Connect(Window wnd, Wnd_MDI &wndMDI);
 void CreateDialog_SmartPaste(Window wndParent, Connection &connection, Prop::Connections &propConnections);
 void CreateDialog_InputWindow(Window wndParent, InputControl &input_window, Prop::InputWindow &propInputWindow);
@@ -150,9 +150,9 @@ void Global_PropChange()
 
 Events::SendersOf<GlobalTextSettingsModified, GlobalInputSettingsModified> g_text_events;
 
-void OnGlobalTextSettingsModified()
+void OnGlobalTextSettingsModified(Prop::TextWindow &prop)
 {
-   g_text_events.Send(GlobalTextSettingsModified{});
+   g_text_events.Send(GlobalTextSettingsModified{prop});
 }
 
 void OnGlobalInputSettingsModified(Prop::InputWindow &prop)
@@ -282,7 +282,7 @@ void SpawnWindow::On(Text::Wnd &wndText, Text::Wnd_View &wndView, const Msg::RBu
 
 void SpawnWindow::On(const GlobalTextSettingsModified &event)
 {
-   if(mp_prop_text_window==&GlobalTextSettings())
+   if(mp_prop_text_window==&event.prop)
       ::SetTextWindowProperties(*mp_text, *mp_prop_text_window);
 }
 
@@ -985,7 +985,7 @@ void Wnd_Main::On(Text::Wnd &wndText, Text::Wnd_View &wndView, const Msg::RButto
 #endif
       menu.AppendSeparator();
       menu.Append(p_props==&GlobalTextSettings() ? MF_CHECKED : MF_UNCHECKED, "Use global settings", [&]() { ToggleGlobalSettings(wndText, p_props); });
-      menu.Append(0, "Settings...", [&]() { CreateDialog_TextWindow(*this, wndText, *p_props); });
+      menu.Append(0, "Settings...", [&]() { CreateDialog_TextWindow(*this, *p_props); });
 
       if(p_line)
          text(FindWord(p_line->GetText(), location_info.m_find_element.m_text_index));
@@ -1227,7 +1227,6 @@ bool SaveDockedWindowSettings(Prop::DockedWindow &propWindow, Wnd_Docking &windo
          Prop::WebViewWindow &prop=propWindow.propWebViewWindow();
          prop.pclURL(pWnd->GetURL());
          prop.pclID(pWnd->GetID());
-         prop.fHostObjects(pWnd->HostObjects());
          return true;
       }
    }
@@ -1796,9 +1795,9 @@ void Wnd_Main::ApplyHistoryVisibility()
 void Wnd_Main::On(const GlobalTextSettingsModified &event)
 {
    // If any of our text windows use the global settings, refresh them
-   if(mp_prop_output==&GlobalTextSettings())
+   if(mp_prop_output==&event.prop)
       ::SetTextWindowProperties(*mp_wnd_text, *mp_prop_output);
-   if(mp_prop_history==&GlobalTextSettings())
+   if(mp_prop_history==&event.prop)
       ::SetTextWindowProperties(*mp_wnd_text_history, *mp_prop_history);
 }
 


### PR DESCRIPTION
Update web page style with the current input & output window styles, so the webview can match the user's preferences easily. See the `<head><style>` section of the html

Add AddToInputHistory function