### PR TITLE
Auto hide input history

### DIFF
--- a/src/Dlg_Settings.cpp
+++ b/src/Dlg_Settings.cpp
@@ -232,6 +232,7 @@ private:
 
    AL::CheckBox *m_pcbSendUnrecognizedCommands;
    AL::CheckBox *m_pcbPreventSmartQuotes;
+   AL::CheckBox *m_pcbAutoShowHistory;
 
    AL::CheckBox *m_pcbSpellCheck;
    Controls::TComboBox<OwnedString> m_coSpellLanguage;
@@ -247,6 +248,7 @@ void Dlg_Input::Save()
    // Windows
    g_ppropGlobal->fSendUnrecognizedCommands(m_pcbSendUnrecognizedCommands->IsChecked());
    g_ppropGlobal->fPreventSmartQuotes(m_pcbPreventSmartQuotes->IsChecked());
+   g_ppropGlobal->fAutoShowHistory(m_pcbAutoShowHistory->IsChecked());
 
    // SpellCheck
    {
@@ -287,6 +289,10 @@ void Dlg_Input::OnCreate()
 
       m_pcbPreventSmartQuotes=m_layout.CreateCheckBox(-1, "Prevent smart quote mode (no “” quotes, only \")");
       g << m_pcbPreventSmartQuotes;
+
+      m_pcbAutoShowHistory=m_layout.CreateCheckBox(-1, "Automatically show history window while navigating input history");
+      g << m_pcbAutoShowHistory;
+
    }
 
    {
@@ -304,6 +310,7 @@ void Dlg_Input::OnCreate()
 
    m_pcbSendUnrecognizedCommands->Check(g_ppropGlobal->fSendUnrecognizedCommands());
    m_pcbPreventSmartQuotes->Check(g_ppropGlobal->fPreventSmartQuotes());
+   m_pcbAutoShowHistory->Check(g_ppropGlobal->fAutoShowHistory());
 
    // Spell Check
    {

--- a/src/Main.h
+++ b/src/Main.h
@@ -2,7 +2,6 @@
 #include "Objects_Sockets2.h"
 #include "Objects_Sockets_TLS.h"
 #include "Text\TextWindow.h"
-#include "Resource.h"
 #include "BuildNumber.h"
 #include "Keys.h"
 
@@ -22,7 +21,7 @@
 #define YARN 1
 #define DWRITE_TEST 1
 #else
-#define BETA_BUILD 3
+#define BETA_BUILD 5
 #define SCRIPTING 0
 #define YARN 0
 #define DWRITE_TEST 0
@@ -126,6 +125,7 @@ extern Events::SendersOf<GlobalTextSettingsModified, GlobalInputSettingsModified
 Prop::TextWindow &GlobalTextSettings();
 Prop::InputWindow &GlobalInputSettings();
 void OnGlobalTextSettingsModified(Prop::TextWindow &prop); // Called by the text dialog when changing settings
+void OnGlobalInputSettingsModified(Prop::InputWindow &prop); // Called by the input dialog when changing settings
 
 void CreateDialog_KeyboardMacros(Window wnd, Prop::Server *ppropServer, Prop::Character *ppropCharacter);
 void CloseDialog_KeyboardMacros();

--- a/src/Root.prp
+++ b/src/Root.prp
@@ -309,7 +309,7 @@ Prop MainWindowSettings(RefCounted)
 
    Int  InputSize = 50
    Int  HistorySize = 40
-   Flag History = true
+   Flag History = false // When false, autohistory applies
 }
 
 Prop Windows
@@ -1009,6 +1009,7 @@ Prop Global
    Flag SendUnrecognizedCommands = false
    Flag PreventSmartQuotes = true
 
+   Flag AutoShowHistory = true // When true, history window will appear automatically when navigating history
    Flag NewContentMarker = true
    Flag TaskbarBadge = true
    String VoiceID

--- a/src/Wnd_Main.cpp
+++ b/src/Wnd_Main.cpp
@@ -1516,6 +1516,7 @@ void Wnd_Main::SendInput(InputControl &edInput)
    m_history_pos=~0U; // Reset the current history item
    mp_wnd_text_history->SetUserPaused(false);
    Assert(!mp_wnd_text_history->IsPaused());
+   ApplyHistoryVisibility();
 
    auto string=edInput.GetText();
 
@@ -1610,6 +1611,7 @@ void Wnd_Main::History_SelectUp(InputControl &edInput)
    }
 
    CheckInputHeight();
+   ApplyHistoryVisibility();
 }
 
 void Wnd_Main::History_SelectDown(InputControl &edInput)
@@ -1641,6 +1643,7 @@ void Wnd_Main::History_SelectDown(InputControl &edInput)
    }
 
    CheckInputHeight();
+   ApplyHistoryVisibility();
 }
 
 void Wnd_Main::History_SelectLine(InputControl &edInput)
@@ -1784,9 +1787,10 @@ void Wnd_Main::ApplyMainWindowSettings()
 void Wnd_Main::ApplyHistoryVisibility()
 {
    auto &settings=GetWindowSettings();
-   mp_splitter->SetVisibility(1, settings.fHistory());
-   mp_wnd_text_history->Show(settings.fHistory() ? SW_SHOW : SW_HIDE);
-   mp_wnd_text_history->GetTextList().SelectionClear();
+   bool visible=settings.fHistory() || g_ppropGlobal->fAutoShowHistory() && m_history_pos!=~0U;
+
+   mp_splitter->SetVisibility(1, visible);
+   mp_wnd_text_history->Show(visible ? SW_SHOW : SW_HIDE);
 
    mp_layout->CalcMinSize();
    mp_layout->Update();


### PR DESCRIPTION
Change showing the history window to off by default
Add new global option to auto show/hide history when navigating through it