### PR TITLE
Make spawn windows not appear during replay log

### DIFF
--- a/Assets/Changes.txt
+++ b/Assets/Changes.txt
@@ -1,7 +1,10 @@
 4.00.329
 
 Fix issue with multiline triggers with a 0 timeout duration not being infinite time
-
+Remove connection point OLE code, hasn't been used in decades
+Add window title setting to input windows (mainly useful for scripts)
+Add IWindowMain::GetSpawnTabs and IWindowMain::GetInput to allow scripts to do actions on spawn tab switching
+With restore logs, spawn triggers will only add to existing windows/tabs vs creating new ones
 
 4.00.328 - 2024-11-18
 

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -1620,22 +1620,25 @@ void Connection::TriggersExecute(Text::Line &line, Array<CopyCntPtrTo<Prop::Trig
                if(prop.fActive() && !mp_captured_spawn_window && !state.mp_spawn_window)
                {
                   FindStringReplacement replacement(search, prop.pclTitle());
-                  state.mp_spawn_window=&GetMainWindow().GetSpawnWindow(prop, replacement, !state.m_no_activity);
-                  state.mp_spawn_window->m_gag_log=prop.fGagLog();
-                  state.mp_spawn_trigger=ppropTrigger;
-
-                  // If there is no capture until set, and we have one, set this trigger as the capture until
-                  if(prop.pclCaptureUntil())
-                     state.mp_spawn_window->mp_capture_until=ppropTrigger;
-
-                  if(mp_trigger_debug)
+                  state.mp_spawn_window=GetMainWindow().GetSpawnWindow(prop, replacement, !state.m_no_activity, m_raw_log_replay);
+                  if(state.mp_spawn_window)
                   {
-                     FixedStringBuilder<256> string("Redirecting to spawn window: <b>", Text::NoHTML{replacement}, "</b>");
-                     if(prop.pclTabGroup())
-                        string(" on tab: <b>", Text::NoHTML{prop.pclTabGroup()});
-                     TriggerDebugText("#000040", "blue", "10", string);
+                     state.mp_spawn_window->m_gag_log=prop.fGagLog();
+                     state.mp_spawn_trigger=ppropTrigger;
+
+                     // If there is no capture until set, and we have one, set this trigger as the capture until
                      if(prop.pclCaptureUntil())
-                        TriggerDebugText("#000040", "blue", "10", FixedStringBuilder<256>("Capture until set: <b>", Text::NoHTML{prop.pclCaptureUntil()}));
+                        state.mp_spawn_window->mp_capture_until=ppropTrigger;
+
+                     if(mp_trigger_debug)
+                     {
+                        FixedStringBuilder<256> string("Redirecting to spawn window: <b>", Text::NoHTML{replacement}, "</b>");
+                        if(prop.pclTabGroup())
+                           string(" on tab: <b>", Text::NoHTML{prop.pclTabGroup()});
+                        TriggerDebugText("#000040", "blue", "10", string);
+                        if(prop.pclCaptureUntil())
+                           TriggerDebugText("#000040", "blue", "10", FixedStringBuilder<256>("Capture until set: <b>", Text::NoHTML{prop.pclCaptureUntil()}));
+                     }
                   }
                }
             }

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -204,7 +204,7 @@ struct Connection
    struct Event_Log { };
 
    Events::SendersOf<Event_Log, Event_Send, Event_Receive, Event_Display, Event_Activity, Event_Connect, Event_Disconnect, Event_GMCP> m_events;
-   template<class TEvent> operator Events::SenderOf<TEvent> &() { return m_events.Get<TEvent>(); }
+   template<typename TEvent> operator Events::SenderOf<TEvent> &() { return m_events.Get<TEvent>(); }
 
    OwnedString m_grab_prefix; // If non empty, we're watching for a grab prefix to put into the input window
 

--- a/src/Wnd_Main.h
+++ b/src/Wnd_Main.h
@@ -7,7 +7,7 @@
 
 namespace OM
 {
-class MainWindow;
+struct MainWindow;
 };
 
 struct Scripter;
@@ -123,6 +123,7 @@ struct SpawnWindow
 struct SpawnTabsWindow
  : DLNode<SpawnTabsWindow>,
    Wnd_Dialog,
+   Events::Sends_Deleted,
    Windows::AutoLayout::Tab::INotify
 {
    SpawnTabsWindow(SpawnTabsWindow *p_insert_after, Wnd_Main &wnd_main, ConstString title);
@@ -132,7 +133,7 @@ struct SpawnTabsWindow
    unsigned GetUnreadCount() const;
    void AfterRestore();
 
-   SpawnWindow &GetTab(ConstString title, Prop::TextWindow *pprops=nullptr, bool hilight=true);
+   SpawnWindow *GetTab(ConstString title, Prop::TextWindow *pprops, bool hilight, bool use_existing);
    void SetVisible(SpawnWindow &window);
    bool SetVisible(ConstString title);
    OwnedString m_title;
@@ -243,7 +244,7 @@ struct Wnd_Main
    void TabColor(Color color);
 
    SpawnTabsWindow *FindSpawnTabsWindow(ConstString title);
-   SpawnWindow &GetSpawnWindow(const Prop::Trigger_Spawn &trigger, ConstString title, bool fHilight);
+   SpawnWindow *GetSpawnWindow(const Prop::Trigger_Spawn &trigger, ConstString title, bool hilight, bool use_existing);
    Wnd_Image *GetImageWindow() { return mp_wnd_image; }
    Wnd_Image &EnsureImageWindow();
    Stats::Wnd &GetStatsWindow(ConstString title, bool fDock=true);
@@ -538,7 +539,7 @@ private:
    Collection<Variable> m_variables;
 
    CntPtrTo<OM::MainWindow> mp_dispatch;
-   friend class OM::MainWindow;
+   friend struct OM::MainWindow;
 };
 
 struct Wnd_MDI : TWindowImpl<Wnd_MDI>, DLNode<Wnd_MDI>


### PR DESCRIPTION
When launching app, restore spawn global defaults properly