### PR TITLE
Make script trigger search include the match text vs just description

### DIFF
--- a/Assets/Changes.txt
+++ b/Assets/Changes.txt
@@ -1,4 +1,13 @@
-4.00.329
+4.00.330
+
+Fixed regression where a maximized window would not restore to the correct size
+Added input window option 'Enable WM_GETOBJECT' to allow utilities like grammarly to work (disabled by default to prevent misbehaving 3rd party apps)
+Fix map editor so that selecting 0 sized images/labels will work, previously only select-all could select them
+Fix map crash when moving exits and using undo (selection got out of sync with reality)
+Fix map editor removing exits when rooms overlap and exits is contained within overlap region
+Map smart location now watches exit names the user types to reduce ambiguity
+
+4.00.329 - 2025-6-13
 
 Add ability to log to more than one file at once
 Fix issue with multiline triggers with a 0 timeout duration not being infinite time
@@ -19,6 +28,7 @@ Add /opendialog command to open aliases/triggers/macros/worlds/settings dialog b
 Add /opendialog settings (section name) command, to open a specific section in the settings
 Add %variable% expansion to spawns, sound, and filter triggers
 Add more keyboard shortcuts for menu items
+Show '*' taskbar badge symbol when there's important activity (Badges work for Windows 11 store app only)
 
 4.00.328 - 2024-11-18
 

--- a/Assets/SampleConfig.txt
+++ b/Assets/SampleConfig.txt
@@ -1,23 +1,53 @@
-Version=322
+Version=329
 Windows
 {
-  MDIPosition=(228,228,2880,1537)
+  MDIPosition=(653,37,1480,882)
 }
 Connections
 {
   Logging.RestoreBufferSizeCurrent=256
-  KeyboardMacros
+  "KeyboardMacros2"
   {
-    ""=Control+Alt+A,"OOC Quick Message: Something's come up in RL. I'll be back momentarily"
-    ""=NumPad1,"SW"
-    ""=NumPad2,"S"
-    ""=NumPad3,"SE"
-    ""=NumPad4,"W"
-    ""=NumPad6,"E"
-    ""=NumPad7,"NW"
-    ""=NumPad8,"N"
-    ""=NumPad9,"NE"
-    ""=Control+T,"/@window.input.Set(\"@emit \"+window.input.get().replace(/\\n/g, \"\\n@emit \"));"
+    {
+      Macro="OOC Quick Message: Something's come up in RL. I'll be back momentarily"
+      key=Control+Alt+A
+    }
+    {
+      Macro="SW"
+      key=NumPad1
+    }
+    {
+      Macro="S"
+      key=NumPad2
+    }
+    {
+      Macro="SE"
+      key=NumPad3
+    }
+    {
+      Macro="W"
+      key=NumPad4
+    }
+    {
+      Macro="E"
+      key=NumPad6
+    }
+    {
+      Macro="NW"
+      key=NumPad7
+    }
+    {
+      Macro="N"
+      key=NumPad8
+    }
+    {
+      Macro="NE"
+      key=NumPad9
+    }
+    {
+      Macro="/@window.input.Set(\"@emit \"+window.input.get().replace(/\\n/g, \"\\n@emit \"));"
+      key=Control+T
+    }
   }
   Shortcuts
   {
@@ -56,7 +86,10 @@ Connections
       {
         Unnamed
         {
-          Docking.ClientSize={2858,1415}
+          Docking
+          {
+            ClientSize={1458,791}
+          }
           MainWindowSettings.InputSize=25
         }
       }
@@ -72,6 +105,8 @@ Connections
         {
           Connect="/delay 3s \"connect %NAME% %PASSWORD%\""
           Password="guest"
+          LastUsed=2023-4-21-17-53-28-429
+          Created=2023-4-21-17-53-38-815
           Docking
           {
             ClientSize={2858,1415}
@@ -139,7 +174,6 @@ Connections
           {
             InputSize=25
             HistorySize=0
-            History=false
             History
             {
               ForeColor=RGB(0,128,64)
@@ -713,7 +747,7 @@ Connections
         {
           Description="OOC poses"
           Example="(OOC) Frank says \"Whose pose is it?\""
-          CooldownTime=5
+          CooldownTime=5.0
           FindString
           {
             MatchText="^[(\\[<]OOC[)\\]>](.+)"
@@ -845,6 +879,27 @@ Connections
   }
   Aliases
   {
+    Active=true
+    {
+      Description="Repeat 'buy torch' command n times"
+      Example="bt 5"
+      Replace="/script for(i=0;i<\\1;i++) { window.run(\"buy torch\"); }"
+      FindString
+      {
+        MatchText="bt (\\d+)"
+        RegularExpression=true
+      }
+    }
+    {
+      Description="Repeat 'eat food' command n times"
+      Example="eat 5"
+      Replace="/script for(i=0;i<\\1;i++) { window.run(\"eat food\"); }"
+      FindString
+      {
+        MatchText="eat (\\d+)"
+        RegularExpression=true
+      }
+    }
     {
       Description="Nicknames for Friends"
       Folder=true

--- a/src/App_OM.cpp
+++ b/src/App_OM.cpp
@@ -220,7 +220,7 @@ STDMETHODIMP Triggers::get_Item(VARIANT var, ITrigger** retval)
    {
       BSTRToLStr string(var.bstrVal);
       for(auto &v : *m_propTriggers)
-         if(v->pclDescription()==string)
+         if(v->pclDescription() && v->pclDescription()==string || v->propFindString().pclMatchText()==string)
             return RefReturner(retval)(MakeCounting<Trigger>(*v, m_propTriggers));
    }
 

--- a/src/Commands.cpp
+++ b/src/Commands.cpp
@@ -167,7 +167,7 @@ try
          return;
       }
 
-      static constexpr ConstString c_helpPage[]={
+      static constexpr ConstString c_help_page[]={
          "",
          "<p align='center'><font color='silver'><b><u>  " gd_pcTitle " - Command Line Help  </u></b>",
          "/@ $ - Run an immediate script, $ can span multiple lines of text",
@@ -233,7 +233,7 @@ try
          "<p align='center'><A href='" HELP_URL "CommandLine.md'>Click here for the online version with more details</a>",
       };
 
-      for(auto &line : c_helpPage)
+      for(auto &line : c_help_page)
          mp_wnd_text->AddHTML(line);
 
       return;

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -1316,7 +1316,11 @@ void Connection::Display(UniquePtr<Text::Line> &&p_line)
 
    RemovePrompt();
    if(!state.m_no_activity)
+   {
+      if(mp_trigger_debug && !m_wnd_main.ShowActivityOnTaskbar())
+         TriggerDebugText("#000040", "blue", "5", "OS Taskbar activity muted as tab option 'Show Activity On Taskbar' is unchecked");
       m_events.Send(Event_Activity());
+   }
 
    Text::Wnd *p_wnd=&GetOutput();
 
@@ -1748,7 +1752,11 @@ void Connection::RunTriggers(Text::Line &line, Array<CopyCntPtrTo<Prop::Trigger>
             if(!m_raw_log_replay && ppropTrigger->fPropSound() && ppropTrigger->propSound().fActive())
             {
                if(!m_mute_audio)
-                  PlaySound(ppropTrigger->propSound().pclSound());
+               {
+                  FindStringReplacement replacement(ppropTrigger->propSound().pclSound());
+                  replacement.ExpandVariables(GetVariables());
+                  PlaySound(ExpandEnvironmentStrings(replacement));
+               }
                if(mp_trigger_debug)
                   TriggerDebugText("#000040", "blue", "10", "Playing sound");
             }

--- a/src/Dlg_Settings.cpp
+++ b/src/Dlg_Settings.cpp
@@ -268,6 +268,7 @@ void Dlg_Input::OnCreate()
       AddBool(g, "Send unrecognized commands to server", g_ppropGlobal->fSendUnrecognizedCommands());
       AddBool(g, "Prevent smart quote mode (no “” quotes, only \")", g_ppropGlobal->fPreventSmartQuotes());
       AddBool(g, "Automatically show history window while navigating input history", g_ppropGlobal->fAutoShowHistory());
+      AddBool(g, "Allow WM_GETOBJECT for accessibility", g_ppropGlobal->fEnableGetObject());
    }
 
    {

--- a/src/FindString.cpp
+++ b/src/FindString.cpp
@@ -100,7 +100,8 @@ void FindStringReplacement::ExpandVariables(Prop::Variables &variables)
       unsigned second=m_replacement.FindFirstAt('%', first+1);
       if(second==~0U)
       {
-         ConsoleText("Warning: Send trigger action missing second '%'");
+         HybridStringBuilder<> message("Warning: Missing second '%' when processing: ", *this);
+         ConsoleText(message);
          break;
       }
 

--- a/src/Main.h
+++ b/src/Main.h
@@ -21,7 +21,7 @@
 #define YARN 1
 #define DWRITE_TEST 1
 #else
-#define BETA_BUILD 4
+#define BETA_BUILD 2
 #define SCRIPTING 0
 #define YARN 0
 #define DWRITE_TEST 0

--- a/src/Root.prp
+++ b/src/Root.prp
@@ -1041,6 +1041,7 @@ Prop Global
    Flag PreventSmartQuotes = true
    Flag LayoutWithCtrl = false
    Flag NetworkMessagesInSpawns = true
+   Flag EnableGetObject = false
 
    Flag AutoShowHistory = true // When true, history window will appear automatically when navigating history
    Flag NewContentMarker = true

--- a/src/Str_English.h
+++ b/src/Str_English.h
@@ -430,7 +430,7 @@
     "Open a new edit window", \
     "Output Window - Find", \
     "Input History Window - Find", \
-    "Output Window - Select all", \
+    "Input Window - Select all", \
     "Input Window - Paste", \
     "Output Window - Pause", \
     "Smart Paste", \

--- a/src/Wnd_Main.cpp
+++ b/src/Wnd_Main.cpp
@@ -2461,7 +2461,7 @@ void Wnd_Main::SendLine(ConstString _string, ConstString prefix)
    if(mp_connection->ProcessAliases(string))
    {
       if(g_ppropGlobal->propConnections().propAliases().fEcho())
-         mp_connection->Text(string, Colors::Green);
+         mp_connection->Text(HybridStringBuilder<>("ℹ <font color='green'>Echoing alias result: </font>", string));
 
       bool process_commands=g_ppropGlobal->propConnections().propAliases().fProcessCommands();
       ConstString lines=string;

--- a/src/Wnd_Taskbar.cpp
+++ b/src/Wnd_Taskbar.cpp
@@ -502,7 +502,6 @@ void Wnd_Taskbar::Paint()
          float width=mp_font_emoji->Measure(c_toolbar_items[i].m_icon, m_font_size);
          float x=(CalculateToolbarX(i)+CalculateToolbarX(i+1))/2;
          mp_font_emoji->Draw(c_toolbar_items[i].m_icon, m_font_size, float2(x-width/2.0f, top), *mp_render_target, *mp_brush_dynamic);
-         top; width; x;
       }
    }
 


### PR DESCRIPTION
Add trigger debugger warning when OS taskbar activity muted Add WM_GETOBJECT option for input window accessibility Better warning for missing a second '%' during variable expansion