### PR TITLE
Latest updates

### DIFF
--- a/Assets/Changes.txt
+++ b/Assets/Changes.txt
@@ -1,11 +1,27 @@
-4.00.330
+4.00.331
+
+Separate out map live tracking into two separate options, "Track based on what is seen" and "Track based on what you type"
+Make % variable expansion optional in filter trigger actions
+Fixed a crash in global UI settings when trying to set a default with no color selected
+Fixed a crash when trying to send text in a connecting TLS connection (sending during the DNS lookup window can hit this) 
+Added ability to set id as a string value in /delay command (/delay id "blah" 5s "foo")
+Added width/height value fields to webview.open
+Add webview.close GMCP command to close existing webviews by id
+Add /shelp command to get scripting help of the available objects directly from the internal metadata
+Add world/character/puppet names to undocked window titles
+Add WebView::GetPropertyString("ID")
+Parse <img src=> tags in Pueblo mode for better inline image display
+Extend trigger \# replacement to add \a## to support up to 99 capture groups
+
+4.00.330 - 2025-10-18
 
 Fixed regression where a maximized window would not restore to the correct size
 Added input window option 'Enable WM_GETOBJECT' to allow utilities like grammarly to work (disabled by default to prevent misbehaving 3rd party apps)
 Fix map editor so that selecting 0 sized images/labels will work, previously only select-all could select them
 Fix map crash when moving exits and using undo (selection got out of sync with reality)
-Fix map editor removing exits when rooms overlap and exits is contained within overlap region
+Fix map editor removing exits when rooms overlap and exits are contained within overlap region
 Map smart location now watches exit names the user types to reduce ambiguity
+Update telnet TTYPE to follow spec here: https://tintin.mudhalla.net/protocols/mtts/
 
 4.00.329 - 2025-6-13
 

--- a/src/App_OM.cpp
+++ b/src/App_OM.cpp
@@ -130,7 +130,7 @@ STDMETHODIMP Trigger::Delete(VARIANT_BOOL *retval)
    return S_OK;
 }
 
-STDMETHODIMP Trigger::get_FindString(IFindString **retval)
+STDMETHODIMP Trigger::get_FindString(I::FindString **retval)
 {
    return RefReturner(retval)(MakeCounting<FindString>(*m_propTrigger));
 }
@@ -195,7 +195,7 @@ STDMETHODIMP Trigger::put_Away(VARIANT_BOOL flag)
    m_propTrigger->fAway(VariantBool(flag)); return S_OK;
 }
 
-STDMETHODIMP Trigger::get_Triggers(ITriggers **retval)
+STDMETHODIMP Trigger::get_Triggers(I::Triggers **retval)
 {
    return RefReturner(retval)(MakeCounting<Triggers>(m_propTrigger->propTriggers()));
 }
@@ -204,7 +204,7 @@ Triggers::Triggers(Prop::Triggers &propTriggers) : m_propTriggers(propTriggers)
 {
 }
 
-STDMETHODIMP Triggers::get_Item(VARIANT var, ITrigger** retval)
+STDMETHODIMP Triggers::Item(VARIANT var, I::Trigger** retval)
 {
    Variant v2;
    if(v2.Convert<uint32>(var))
@@ -232,6 +232,16 @@ STDMETHODIMP Triggers::get_Count(long *retval)
    *retval=m_propTriggers->Count(); return S_OK;
 }
 
+STDMETHODIMP Triggers::get_Active(VARIANT_BOOL *flag)
+{
+   *flag=BoolVariant(m_propTriggers->fActive()); return S_OK;
+}
+
+STDMETHODIMP Triggers::put_Active(VARIANT_BOOL flag)
+{
+   m_propTriggers->fActive(VariantBool(flag)); return S_OK;
+}
+
 STDMETHODIMP Triggers::Delete(long index)
 {
    if(static_cast<unsigned int>(index)>=m_propTriggers->Count())
@@ -240,7 +250,7 @@ STDMETHODIMP Triggers::Delete(long index)
    return S_OK;
 }
 
-STDMETHODIMP Triggers::AddCopy(ITrigger *pITrigger, ITrigger **retval)
+STDMETHODIMP Triggers::AddCopy(I::Trigger *pITrigger, I::Trigger **retval)
 {
    Trigger *pTrigger=static_cast<Trigger *>(pITrigger);
    auto pCopy=MakeCounting<Prop::Trigger>(*pTrigger->m_propTrigger);
@@ -258,7 +268,6 @@ STDMETHODIMP Triggers::Move(long from, long to)
 
    return E_FAIL; // NYI
 }
-
 
 Alias::Alias(Prop::Alias &prop_alias, Prop::Aliases *p_prop_aliases)
    : m_prop_alias{prop_alias}, mp_prop_aliases{p_prop_aliases}
@@ -289,7 +298,7 @@ Aliases::Aliases(Prop::Aliases &prop_aliases) : m_prop_aliases{prop_aliases}
 {
 }
 
-STDMETHODIMP Aliases::get_Item(VARIANT var, IAlias **retval)
+STDMETHODIMP Aliases::Item(VARIANT var, I::Alias **retval)
 {
    Variant v2;
    if(v2.Convert<uint32>(var))
@@ -393,12 +402,12 @@ STDMETHODIMP Puppet::put_ConnectWithPlayer(VARIANT_BOOL flag)
    m_propPuppet->fConnectWithPlayer(VariantBool(flag)); return S_OK;
 }
 
-STDMETHODIMP Puppet::get_Triggers(ITriggers **retval)
+STDMETHODIMP Puppet::get_Triggers(I::Triggers **retval)
 {
    return RefReturner(retval)(MakeCounting<Triggers>(m_propPuppet->propTriggers()));
 }
 
-STDMETHODIMP Puppet::get_Aliases(IAliases **retval)
+STDMETHODIMP Puppet::get_Aliases(I::Aliases **retval)
 {
    return RefReturner(retval)(MakeCounting<Aliases>(m_propPuppet->propAliases()));
 }
@@ -407,7 +416,7 @@ Puppets::Puppets(Prop::Puppets &propPuppets) : m_propPuppets(propPuppets)
 {
 }
 
-STDMETHODIMP Puppets::get_Item(VARIANT var, IPuppet **retval)
+STDMETHODIMP Puppets::Item(VARIANT var, I::Puppet **retval)
 {
    RefReturner returner(retval);
 
@@ -506,17 +515,17 @@ STDMETHODIMP Character::get_TimeCreated(VARIANT *retval)
    return SystemTimeToVariant(*retval, m_propCharacter->timeCreated());
 }
 
-STDMETHODIMP Character::get_Triggers(ITriggers **retval)
+STDMETHODIMP Character::get_Triggers(I::Triggers **retval)
 {
    return RefReturner(retval)(MakeCounting<Triggers>(m_propCharacter->propTriggers()));
 }
 
-STDMETHODIMP Character::get_Aliases(IAliases **retval)
+STDMETHODIMP Character::get_Aliases(I::Aliases **retval)
 {
    return RefReturner(retval)(MakeCounting<Aliases>(m_propCharacter->propAliases()));
 }
 
-STDMETHODIMP Character::get_Puppets(IPuppets **retval)
+STDMETHODIMP Character::get_Puppets(I::Puppets **retval)
 {
    return RefReturner(retval)(MakeCounting<Puppets>(m_propCharacter->propPuppets()));
 }
@@ -525,7 +534,7 @@ Characters::Characters(Prop::Server &propServer) : m_propServer(propServer)
 {
 }
 
-HRESULT Characters::get_Item(VARIANT var, ICharacter** retval)
+HRESULT Characters::Item(VARIANT var, I::Character** retval)
 {
    RefReturner returner(retval);
 
@@ -602,17 +611,17 @@ STDMETHODIMP World::put_Host(BSTR bstr)
    m_propServer->pclHost(BSTRToLStr(bstr)); return S_OK;
 }
 
-STDMETHODIMP World::get_Characters(ICharacters **retval)
+STDMETHODIMP World::get_Characters(I::Characters **retval)
 {
    return RefReturner(retval)(MakeCounting<Characters>(*m_propServer));
 }
 
-STDMETHODIMP World::get_Triggers(ITriggers **retval)
+STDMETHODIMP World::get_Triggers(I::Triggers **retval)
 {
    return RefReturner(retval)(MakeCounting<Triggers>(m_propServer->propTriggers()));
 }
 
-STDMETHODIMP World::get_Aliases(IAliases **retval)
+STDMETHODIMP World::get_Aliases(I::Aliases **retval)
 {
    return RefReturner(retval)(MakeCounting<Aliases>(m_propServer->propAliases()));
 }
@@ -621,7 +630,7 @@ Worlds::Worlds() : m_propServers(g_ppropGlobal->propConnections().propServers())
 {
 }
 
-STDMETHODIMP Worlds::get_Item(VARIANT var, IWorld **retval)
+STDMETHODIMP Worlds::Item(VARIANT var, I::World **retval)
 {
    RefReturner returner(retval);
 
@@ -656,7 +665,7 @@ STDMETHODIMP Worlds::get_Count(long *retval)
 
 STDMETHODIMP App::QueryInterface(const GUID &id, void **ppvObj)
 {
-   return TQueryInterfaces<IApp>(id, ppvObj);
+   return TQueryInterfaces<I::App>(id, ppvObj);
 }
 
 App::App()
@@ -681,7 +690,7 @@ STDMETHODIMP App::get_BuildDate(DATE *retval)
    return (SystemTimeToVariantTime(&buildTime, retval)!=0) ? S_OK : E_FAIL;
 }
 
-HRESULT App::get_Worlds(IWorlds **retval)
+HRESULT App::get_Worlds(I::Worlds **retval)
 {
    RefReturner returner(retval);
 
@@ -689,7 +698,7 @@ HRESULT App::get_Worlds(IWorlds **retval)
    return returner(m_pIWorlds);
 }
 
-HRESULT App::get_Windows(IWindows **retval)
+HRESULT App::get_Windows(I::Windows **retval)
 {
    RefReturner returner(retval);
 
@@ -697,12 +706,12 @@ HRESULT App::get_Windows(IWindows **retval)
    return returner(m_pIWindows);
 }
 
-HRESULT App::get_Triggers(ITriggers **retval)
+HRESULT App::get_Triggers(I::Triggers **retval)
 {
    return RefReturner(retval)(MakeCounting<Triggers>(g_ppropGlobal->propConnections().propTriggers()));
 }
 
-HRESULT App::get_Aliases(IAliases **retval)
+HRESULT App::get_Aliases(I::Aliases **retval)
 {
    return RefReturner(retval)(MakeCounting<Aliases>(g_ppropGlobal->propConnections().propAliases()));
 }
@@ -712,7 +721,7 @@ STDMETHODIMP App::SetOnNewWindow(IDispatch *pDisp, VARIANT var)
    return ManageHook<Event_NewWindow>(this, m_hookNewWindow, GlobalEvents::GetInstance(), pDisp, var);
 }
 
-STDMETHODIMP App::NewWindow(IWindow_Main **retval)
+STDMETHODIMP App::NewWindow(I::Window_Main **retval)
 {
    return RefReturner(retval)( (new Wnd_Main(Wnd_MDI::GetInstance()))->GetDispatch());
 }
@@ -737,24 +746,24 @@ STDMETHODIMP App::ActiveXObject(BSTR name, IDispatch **retval)
 }
 
 
-STDMETHODIMP App::NewTrigger(ITrigger **retval)
+STDMETHODIMP App::NewTrigger(I::Trigger **retval)
 {
    return RefReturner(retval)(new Trigger(*new Prop::Trigger(), nullptr));
 }
 
-STDMETHODIMP App::NewWindow_FixedText(int iWidth, int iHeight, IWindow_FixedText **retval)
+STDMETHODIMP App::NewWindow_FixedText(int iWidth, int iHeight, I::Window_FixedText **retval)
 {
    return RefReturner(retval)(Create_Window_FixedText(int2(iWidth, iHeight)));
 }
 
-STDMETHODIMP App::NewWindow_Graphics(int iWidth, int iHeight, IWindow_Graphics **retval)
+STDMETHODIMP App::NewWindow_Graphics(int iWidth, int iHeight, I::Window_Graphics **retval)
 {
    return RefReturner(retval)(Create_Window_Graphics(int2(iWidth, iHeight)));
 }
 
-STDMETHODIMP App::NewWindow_Text(int iWidth, int iHeight, IWindow_Text **retval)
+STDMETHODIMP App::NewWindow_Text(int iWidth, int iHeight, I::Window_Text **retval)
 {
-   CntPtrTo<IWindow_Text> pText=new Window_Text(int2(iWidth, iHeight));
+   CntPtrTo<I::Window_Text> pText=new Window_Text(int2(iWidth, iHeight));
    return RefReturner(retval)(pText);
 }
 
@@ -780,12 +789,12 @@ STDMETHODIMP App::OutputDebugText(BSTR bstr)
    ConsoleText(BSTRToLStr(bstr)); return S_OK;
 }
 
-STDMETHODIMP App::CreateInterval(int iTimeOut, IDispatch *pDisp, VARIANT var, ITimer **retval)
+STDMETHODIMP App::CreateInterval(int iTimeOut, IDispatch *pDisp, VARIANT var, I::Timer **retval)
 {
    return RefReturner(retval)(new OMTimer(m_firstTimer.Prev(), pDisp, var, iTimeOut, true));
 }
 
-STDMETHODIMP App::CreateTimeout(int iTimeOut, IDispatch *pDisp, VARIANT var, ITimer **retval)
+STDMETHODIMP App::CreateTimeout(int iTimeOut, IDispatch *pDisp, VARIANT var, I::Timer **retval)
 {
    return RefReturner(retval)(new OMTimer(m_firstTimer.Prev(), pDisp, var, iTimeOut, false));
 }
@@ -826,12 +835,12 @@ void App::OMTimer::OnTimer()
       Kill();
 }
 
-STDMETHODIMP App::New_Socket(ISocket **retval)
+STDMETHODIMP App::New_Socket(I::Socket **retval)
 {
    *retval=new Socket(); (*retval)->AddRef(); return S_OK;
 }
 
-STDMETHODIMP App::New_SocketServer(unsigned int iPort, IDispatch *pDisp, VARIANT var, ISocketServer **retval)
+STDMETHODIMP App::New_SocketServer(unsigned int iPort, IDispatch *pDisp, VARIANT var, I::SocketServer **retval)
 {
    return RefReturner(retval)(new SocketServer(iPort, pDisp, var));
 }

--- a/src/App_OM.h
+++ b/src/App_OM.h
@@ -11,7 +11,7 @@ namespace OM
 struct ForwardDNS;
 struct ReverseDNS;
 
-struct ArrayUInt : Dispatch<IArrayUInt>
+struct ArrayUInt : Dispatch<I::ArrayUInt>
 {
    OwnedArray<uint32> m_array;
 
@@ -19,7 +19,7 @@ struct ArrayUInt : Dispatch<IArrayUInt>
    STDMETHODIMP get_Count(long *retval);
 };
 
-struct FindString : Dispatch<IFindString>
+struct FindString : Dispatch<I::FindString>
 {
    FindString(Prop::Trigger &propTrigger);
 
@@ -42,13 +42,13 @@ private:
    CntRefTo<Prop::Trigger> m_propTrigger;
 };
 
-struct Trigger : Dispatch<ITrigger>
+struct Trigger : Dispatch<I::Trigger>
 {
    Trigger(Prop::Trigger &propTrigger, Prop::Triggers *ppropTriggers);
 
    STDMETHODIMP Delete(VARIANT_BOOL *) override;
 
-   STDMETHODIMP get_FindString(IFindString **) override;
+   STDMETHODIMP get_FindString(I::FindString **) override;
 
    STDMETHODIMP get_Disabled(VARIANT_BOOL *) override;
    STDMETHODIMP put_Disabled(VARIANT_BOOL ) override;
@@ -64,7 +64,7 @@ struct Trigger : Dispatch<ITrigger>
    STDMETHODIMP get_Away(VARIANT_BOOL *) override;
    STDMETHODIMP put_Away(VARIANT_BOOL ) override;
 
-   STDMETHODIMP get_Triggers(ITriggers **) override;
+   STDMETHODIMP get_Triggers(I::Triggers **) override;
 
 private:
    CntRefTo<Prop::Trigger> m_propTrigger;
@@ -72,22 +72,25 @@ private:
    friend struct Triggers;
 };
 
-struct Triggers : Dispatch<ITriggers>
+struct Triggers : Dispatch<I::Triggers>
 {
    Triggers(Prop::Triggers &propTriggers);
 
-   STDMETHODIMP get_Item(VARIANT var, ITrigger **retval) override;
+   STDMETHODIMP Item(VARIANT var, I::Trigger **retval) override;
    STDMETHODIMP get_Count(long *retval) override;
 
+   STDMETHODIMP get_Active(VARIANT_BOOL *) override;
+   STDMETHODIMP put_Active(VARIANT_BOOL) override;
+
    STDMETHODIMP Delete(long index);
-   STDMETHODIMP AddCopy(ITrigger *, ITrigger **);
+   STDMETHODIMP AddCopy(I::Trigger *, I::Trigger **);
    STDMETHODIMP Move(long from, long to);
 
 private:
    CntRefTo<Prop::Triggers> m_propTriggers;
 };
 
-struct Alias : Dispatch<IAlias>
+struct Alias : Dispatch<I::Alias>
 {
    Alias(Prop::Alias &prop_alias, Prop::Aliases *prop_aliases);
 
@@ -101,18 +104,18 @@ private:
    CntPtrTo<Prop::Aliases> mp_prop_aliases;
 };
 
-struct Aliases : Dispatch<IAliases>
+struct Aliases : Dispatch<I::Aliases>
 {
    Aliases(Prop::Aliases &prop_aliases);
 
-   STDMETHODIMP get_Item(VARIANT var, IAlias **retval) override;
+   STDMETHODIMP Item(VARIANT var, I::Alias **retval) override;
    STDMETHODIMP get_Count(long *retval) override;
 
 private:
    CntRefTo<Prop::Aliases> m_prop_aliases;
 };
 
-struct Puppet : Dispatch<IPuppet>
+struct Puppet : Dispatch<I::Puppet>
 {
    Puppet(Prop::Puppet &propPuppet);
 
@@ -131,26 +134,26 @@ struct Puppet : Dispatch<IPuppet>
    STDMETHODIMP get_ConnectWithPlayer(VARIANT_BOOL *);
    STDMETHODIMP put_ConnectWithPlayer(VARIANT_BOOL);
 
-   STDMETHODIMP get_Triggers(ITriggers **);
-   STDMETHODIMP get_Aliases(IAliases **);
+   STDMETHODIMP get_Triggers(I::Triggers **);
+   STDMETHODIMP get_Aliases(I::Aliases **);
 
 private:
    CntRefTo<Prop::Puppet> m_propPuppet;
 };
 
-struct Puppets : Dispatch<IPuppets>
+struct Puppets : Dispatch<I::Puppets>
 {
    Puppets(Prop::Puppets &propPuppets);
 
-   STDMETHODIMP get_Item(VARIANT var, IPuppet **retval);
-   STDMETHODIMP get_Count(long *retval);
+   STDMETHODIMP Item(VARIANT var, I::Puppet **retval) override;
+   STDMETHODIMP get_Count(long *retval) override;
 
 private:
 
    CntRefTo<Prop::Puppets> m_propPuppets;
 };
 
-struct Character : Dispatch<ICharacter>
+struct Character : Dispatch<I::Character>
 {
    Character(Prop::Character &propCharacter);
 
@@ -168,27 +171,27 @@ struct Character : Dispatch<ICharacter>
    STDMETHODIMP get_LastUsed(VARIANT *date);
    STDMETHODIMP get_TimeCreated(VARIANT *date);
 
-   STDMETHODIMP get_Triggers(ITriggers **retval);
-   STDMETHODIMP get_Aliases(IAliases **retval);
-   STDMETHODIMP get_Puppets(IPuppets **retval);
+   STDMETHODIMP get_Triggers(I::Triggers **retval);
+   STDMETHODIMP get_Aliases(I::Aliases **retval);
+   STDMETHODIMP get_Puppets(I::Puppets **retval);
 
 private:
    CntRefTo<Prop::Character> m_propCharacter;
 };
 
-struct Characters : Dispatch<ICharacters>
+struct Characters : Dispatch<I::Characters>
 {
    Characters(Prop::Server &propServer);
 
-   STDMETHODIMP get_Item(VARIANT var, ICharacter **retval);
-   STDMETHODIMP get_Count(long *retval);
+   STDMETHODIMP Item(VARIANT var, I::Character **retval) override;
+   STDMETHODIMP get_Count(long *retval) override;
 
 private:
 
    CntRefTo<Prop::Server> m_propServer;
 };
 
-struct World : Dispatch<IWorld>
+struct World : Dispatch<I::World>
 {
    World(Prop::Server &propServer);
 
@@ -201,20 +204,20 @@ struct World : Dispatch<IWorld>
    STDMETHODIMP get_Host(BSTR *retval);
    STDMETHODIMP put_Host(BSTR bstr);
 
-   STDMETHODIMP get_Characters(ICharacters **retval);
-   STDMETHODIMP get_Triggers(ITriggers **retval);
-   STDMETHODIMP get_Aliases(IAliases **retval);
+   STDMETHODIMP get_Characters(I::Characters **retval);
+   STDMETHODIMP get_Triggers(I::Triggers **retval);
+   STDMETHODIMP get_Aliases(I::Aliases **retval);
 
 private:
    CntRefTo<Prop::Server> m_propServer;
 };
 
-struct Worlds : Dispatch<IWorlds>
+struct Worlds : Dispatch<I::Worlds>
 {
    Worlds();
 
-   STDMETHODIMP get_Item(VARIANT var, IWorld **retval);
-   STDMETHODIMP get_Count(long *retval);
+   STDMETHODIMP Item(VARIANT var, I::World **retval) override;
+   STDMETHODIMP get_Count(long *retval) override;
 
 private:
 
@@ -222,13 +225,13 @@ private:
 };
 
 struct App
-:  Dispatch<IApp>,
+:  Dispatch<I::App>,
    Events::ReceiversOf<App, Event_NewWindow>
 {
    App();
    ~App() noexcept;
 
-   USE_INHERITED_UNKNOWN(IApp)
+   USE_INHERITED_UNKNOWN(I::App)
 
    // IUnknown
    STDMETHODIMP QueryInterface(REFIID riid, void **ppvObj) override;
@@ -240,24 +243,24 @@ struct App
 
    STDMETHODIMP get_ConfigPath(BSTR *retval) override { *retval=LStrToBSTR(GetConfigPath()); return S_OK;}
 
-   STDMETHODIMP get_Worlds(IWorlds **retval) override;
-   STDMETHODIMP get_Windows(IWindows **retval) override;
-   STDMETHODIMP get_Triggers(ITriggers **retval) override;
-   STDMETHODIMP get_Aliases(IAliases **retval) override;
+   STDMETHODIMP get_Worlds(I::Worlds **retval) override;
+   STDMETHODIMP get_Windows(I::Windows **retval) override;
+   STDMETHODIMP get_Triggers(I::Triggers **retval) override;
+   STDMETHODIMP get_Aliases(I::Aliases **retval) override;
 
    STDMETHODIMP ActiveXObject(BSTR name, IDispatch **retval) override;
 
-   STDMETHODIMP NewTrigger(ITrigger **retval) override;
-   STDMETHODIMP NewWindow_FixedText(int iWidth, int iHeight, IWindow_FixedText **retval) override;
-   STDMETHODIMP NewWindow_Text(int iWidth, int iHeight, IWindow_Text **retval) override;
+   STDMETHODIMP NewTrigger(I::Trigger **retval) override;
+   STDMETHODIMP NewWindow_FixedText(int iWidth, int iHeight, I::Window_FixedText **retval) override;
+   STDMETHODIMP NewWindow_Text(int iWidth, int iHeight, I::Window_Text **retval) override;
 
-   STDMETHODIMP NewWindow(IWindow_Main **retval) override;
+   STDMETHODIMP NewWindow(I::Window_Main **retval) override;
    STDMETHODIMP SetOnNewWindow(IDispatch *pDisp, VARIANT var) override;
 
-   STDMETHODIMP CreateInterval(int iTimeOut, IDispatch *pDisp, VARIANT var, ITimer **retval) override;
-   STDMETHODIMP CreateTimeout(int iTimeOut, IDispatch *pDisp, VARIANT var, ITimer **retval) override;
+   STDMETHODIMP CreateInterval(int iTimeOut, IDispatch *pDisp, VARIANT var, I::Timer **retval) override;
+   STDMETHODIMP CreateTimeout(int iTimeOut, IDispatch *pDisp, VARIANT var, I::Timer **retval) override;
 
-   STDMETHODIMP NewWindow_Graphics(int iWidth, int iHeight, IWindow_Graphics **retval) override;
+   STDMETHODIMP NewWindow_Graphics(int iWidth, int iHeight, I::Window_Graphics **retval) override;
 
    STDMETHODIMP PlaySound(BSTR filename, float volume) override;
    STDMETHODIMP StopSounds() override;
@@ -265,8 +268,8 @@ struct App
    STDMETHODIMP OutputDebugHTML(BSTR bstr) override;
    STDMETHODIMP OutputDebugText(BSTR bstr) override;
 
-   STDMETHODIMP New_Socket(ISocket **retval) override;
-   STDMETHODIMP New_SocketServer(unsigned int iPort, IDispatch *pDisp, VARIANT var, ISocketServer **retval) override;
+   STDMETHODIMP New_Socket(I::Socket **retval) override;
+   STDMETHODIMP New_SocketServer(unsigned int iPort, IDispatch *pDisp, VARIANT var, I::SocketServer **retval) override;
 
    STDMETHODIMP ForwardDNSLookup(BSTR bstrHost, IDispatch *pDisp, VARIANT var) override;
    STDMETHODIMP ReverseDNSLookup(BSTR bstrIP, IDispatch *pDisp, VARIANT var) override;
@@ -277,12 +280,12 @@ struct App
 
 private:
 
-   CntPtrTo<IWorlds> m_pIWorlds;
-   CntPtrTo<IWindows> m_pIWindows;
+   CntPtrTo<I::Worlds> m_pIWorlds;
+   CntPtrTo<I::Windows> m_pIWindows;
 
    HookVariant m_hookNewWindow;
 
-   struct OMTimer : Dispatch<ITimer>, DLNode<OMTimer>
+   struct OMTimer : Dispatch<I::Timer>, DLNode<OMTimer>
 
 
    {

--- a/src/Commands.cpp
+++ b/src/Commands.cpp
@@ -16,6 +16,8 @@
 #include "Wnd_Map.h"
 #include "ImageBanner.h"
 #include "WebView.h"
+#include "AI.h"
+#include "OM_Help.h"
 
 void StopSpeech();
 
@@ -169,7 +171,8 @@ try
 
       static constexpr ConstString c_help_page[]={
          "",
-         "<p align='center'><font color='silver'><b><u>  " gd_pcTitle " - Command Line Help  </u></b>",
+         "<p align='center' background-color='#004000' stroke-color='#008000' stroke-width='2' border='10' border-style='round' padding='2'><font color='silver'><b>" gd_pcTitle " - Command Line Help</b>",
+         "<font size='16'>Scripting</font>",
          "/@ $ - Run an immediate script, $ can span multiple lines of text",
          "/silent/(command) - Prefix for any command that will suppress informational messages from it",
          "",
@@ -218,6 +221,7 @@ try
          "/resetscript - Reset the scripting engine (possibly switching languages)",
          "/roll [count]d[sides](+bonus) - Dice roll. Example /roll 10d6",
          "/script $ - Run single line script",
+         "<run text='/shelp'>/shelp</run> ($) - Scripting help",
          "/set $=$ - Set environment variable",
          "/setinput $ - Sets any text after the \"/setinput \" into the active input window",
          "/silence - Stop all playing sounds",
@@ -234,10 +238,30 @@ try
       };
 
       for(auto &line : c_help_page)
-         mp_wnd_text->AddHTML(line);
+         mp_wnd_text->Add(CreateLineInternal(line));
 
       return;
    }
+
+   if(IEquals(command, "shelp"))
+   {
+      if(wl.Count()>1)
+      {
+         HybridStringBuilder string;
+         OM::GetOMHelp(wl[1], *mp_wnd_text);
+      }
+      else
+      {
+         mp_wnd_text->Add(CreateLineInternal(
+            "To get help on any scripting type, use `/shelp [type]`. Click Underlined text for additional help." CRLF
+            "The root types are:" CRLF
+            "  <run text='/shelp App'><font color='#00FFFF'>App</font></run> - ('app' global variable) - The application interface" CRLF
+            "  <run text='/shelp Window_Main'><font color='#00FFFF'>Window_Main</font></run> - ('window' global variable) - The current window the script was launched from" CRLF
+            "  <run text='/shelp WebView'><font color='#00FFFF'>WebView</font></run> - For webviews, this is the interface available to them"));
+      }
+      return;
+   }
+
 
    if(IEquals(command, "makali"))
    {
@@ -265,6 +289,18 @@ try
    if(IEquals(command, "clear"))
    {
       mp_wnd_text->Clear();
+      return;
+   }
+
+   if(IEquals(command, "ai"))
+   {
+      auto &ai=EnsureAIWindow();
+
+      if(command_line.Length()<=command.Length()+1)
+         return;
+
+      auto prompt=command_line.WithoutFirst(command.Length()+1);
+      ai.Request(prompt);
       return;
    }
 
@@ -499,16 +535,15 @@ try
          }
          if(IEquals(wl[1], "kill"))
          {
-            unsigned id;
-            if(wl.Count()<=2 || !wl[2].To(id))
+            if(wl.Count()<=2)
             {
-               mp_wnd_text->AddHTML("<icon error> Bad ID format, should be like: kill 43");
+               mp_wnd_text->AddHTML("<icon error> Missing ID, should be like: kill 43");
                return;
             }
 
             for(auto &v : m_delay_timers)
             {
-               if(v.m_id==id)
+               if(v.m_id==wl[2])
                {
                   if(verbose)
                      mp_wnd_text->AddHTML("<icon information> Timer killed");
@@ -517,12 +552,26 @@ try
                }
             }
 
-            mp_wnd_text->AddHTML("<icon error> Timer ID not found");
+            if(verbose)
+               mp_wnd_text->AddHTML("<icon information> Timer ID not found");
             return;
          }
 
          unsigned wl_index=1;
          bool repeating=false;
+         ConstString id;
+
+         if(IEquals(wl[wl_index], "id"))
+         {
+            if(wl_index+1>=wl.Count())
+            {
+               mp_wnd_text->AddHTML("<icon error> Missing ID after 'id' parameter");
+               return;
+            }
+
+            id=wl[wl_index+1];
+            wl_index+=2;
+         }
 
          if(IEquals(wl[wl_index], "every"))
          {
@@ -533,7 +582,7 @@ try
          float seconds{};
          if(ParseTimeInSeconds(wl[wl_index++], seconds) && wl.Count()==wl_index+1)
          {
-            auto &timer=*new DelayTimer(*this, wl[wl_index], seconds, repeating);
+            auto &timer=*new DelayTimer(*this, wl[wl_index], seconds, id, repeating);
             if(verbose)
             {
                FixedStringBuilder<256> string("<icon information> <font color='green'>Starting timer with ID:", timer.m_id, " in ");
@@ -2135,6 +2184,13 @@ try
          mp_connection->Receive(ConstString("[\x01B[38;5;40m▬▬▬▬▬▬\x01B[38;5;192m▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬\x01B[38;5;124m▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬\x01B[38;5;15m●\x01B[38;5;124m▬▬▬\x01B[0m]" CRLF));
          return;
       }
+
+      if(IEquals(wl[1], "gmcp_clientmedia"))
+      {
+         mp_connection->Receive(ConstString(GMCP_BEGIN R"+(client.media.play { "name":"audio/01_Ultima_Theme.mp3", "url" : "https://prelle.selfhost.eu:4079/", "type" : "music", "volume" : 60, "loops" : 1, "continue" : true })+" GMCP_END));
+         return;
+      }
+
 #endif
 
       if(IEquals(wl[1], "gmcp_beiptest1"))
@@ -2151,8 +2207,23 @@ try
 
       if(IEquals(wl[1], "gmcp_webview"))
       {
-         mp_connection->Receive(ConstString(GMCP_BEGIN R"+(webview.open { "id":"Character editor", "url":"https://beta.flexiblesurvival.com/embedded/c/aleric", "dock":"right", "http-request-headers":{ "Session Key":"Example key", "Username":"Example username" } })+" GMCP_END));
+         mp_connection->Receive(ConstString(GMCP_BEGIN R"+(webview.open { "id":"Character editor", "url":"https://beta.flexiblesurvival.com/embedded/c/aleric", "dock":"right", "height":400, "http-request-headers":{ "Session Key":"Example key", "Username":"Example username" } })+" GMCP_END));
 //         mp_connection->Receive(ConstString(GMCP_BEGIN R"+(webview.open { "id":"Example WebView", "url":"https://www.example.com", "dock":"right", "http-request-headers":{ "Session Key":"Example key", "Username":"Example username" } })+" GMCP_END));
+         return;
+      }
+      if(IEquals(wl[1], "gmcp_webviewwidth"))
+      {
+         mp_connection->Receive(ConstString(GMCP_BEGIN R"+(webview.open { "id":"Character editor", "width":500})+" GMCP_END));
+         return;
+      }
+      if(IEquals(wl[1], "gmcp_webviewheight"))
+      {
+         mp_connection->Receive(ConstString(GMCP_BEGIN R"+(webview.open { "id":"Character editor", "height":500})+" GMCP_END));
+         return;
+      }
+      if(IEquals(wl[1], "gmcp_webviewclose"))
+      {
+         mp_connection->Receive(ConstString(GMCP_BEGIN R"+(webview.close { "id":"Character editor" })+" GMCP_END));
          return;
       }
 

--- a/src/Config.cpp
+++ b/src/Config.cpp
@@ -7,7 +7,7 @@ static bool g_fUseStartupPathForConfig{};
 UniquePtr<RestoreLogs> gp_restore_logs;
 UniquePtr<Prop::Global> g_ppropSample;
 
-File::File g_config_lock;
+Kernel::Mutex g_config_lock;
 
 bool LoadConfig()
 {
@@ -16,7 +16,10 @@ bool LoadConfig()
    // First look for a config.txt in the startup folder, as that's how people used to use it
    File::Path path(name);
    if(!IsStoreApp() && path.Exists())
+   {
       g_fUseStartupPathForConfig=true;
+      path.MakeAbsolute(GetConfigPath());
+   }
    else
    {
       // Look in the %APPDATA%\BeipMU folder
@@ -35,14 +38,18 @@ bool LoadConfig()
       }
    }
 
-   if(!g_config_lock.Open(path) && GetLastError()==ERROR_SHARING_VIOLATION)
+   FixedStringBuilder<256> mutex_path{path};
+   for(unsigned index=0;(index=mutex_path.FindFirstAt('\\', index, ~0U))!=~0U;)
+      mutex_path[index]='/';
+   mutex_path.Insert(0, "Local\\BeipMU_Config_");
+   g_config_lock=Kernel::Mutex(true, mutex_path);
+   if(!g_config_lock || GetLastError()==ERROR_ALREADY_EXISTS)
    {
       MessageBox(nullptr, "The config file is already in use. The most likely cause is that BeipMU is already running.", "Error", MB_ICONERROR|MB_OK);
       return false;
    }
-   g_config_lock.Close();
+
    LoadConfig(path);
-   AssertReturned<true>()==g_config_lock.Open(path);
    return true;
 }
 
@@ -580,8 +587,6 @@ bool SaveConfig(Window wnd, bool allow_gui)
       ConfigExport(filenameNew, g_ppropGlobal, g_ppropGlobal->fShowDefaults(), !allow_gui);
    }
 
-   g_config_lock.Close(); // Release lock on file
-
    // Now replace config.txt with config.new
    if(!MoveFileEx(filenameNew, filename, MOVEFILE_REPLACE_EXISTING|MOVEFILE_WRITE_THROUGH|MOVEFILE_COPY_ALLOWED))
    {
@@ -592,7 +597,6 @@ bool SaveConfig(Window wnd, bool allow_gui)
       return false;
    }
 
-   AssertReturned<true>()==g_config_lock.Open(filename);
    return true;
 }
 

--- a/src/Connection.cpp
+++ b/src/Connection.cpp
@@ -305,6 +305,24 @@ struct JSON_WebView_Open : JSON::Element
          Assert(false);
    }
 
+   void OnNumber(ConstString name, double value) override
+   {
+      if(name=="width")
+         m_size.x=int(value);
+      else if(name=="height")
+         m_size.y=int(value);
+      else
+         Assert(false);
+   }
+
+   void OnBool(ConstString name, bool value) override
+   {
+      if(name=="caption")
+         m_caption=value;
+      else
+         Assert(false);
+   }
+
    JSON::Element &OnObject(ConstString name) override
    {
       if(name=="http-request-headers")
@@ -313,11 +331,26 @@ struct JSON_WebView_Open : JSON::Element
    }
 
    OwnedString m_url, m_id, m_source;
+   int2 m_size{-1, -1};
 
    bool m_docked{};
+   std::optional<bool> m_caption;
    Docking::Side m_docking_side;
 
    JSON_WebView_Headers m_headers;
+};
+
+struct JSON_WebView_Close : JSON::Element
+{
+   void OnString(ConstString name, ConstString value) override
+   {
+      if(name=="id")
+         m_id=value;
+      else
+         Assert(false);
+   }
+
+   OwnedString m_id;
 };
 
 void Connection::OnGMCP(ConstString string)
@@ -395,17 +428,50 @@ bool Connection::OnGMCP_Parse(ConstString string)
             Wnd_WebView *p_webview{};
             if(element.m_id)
                p_webview=m_wnd_main.FindWebView(element.m_id);
+
+            {
+               int2 size=p_webview ? p_webview->WindowSize() : int2(800, 600);
+               if(element.m_size.x==-1)
+                  element.m_size.x=size.x;
+               if(element.m_size.y==-1)
+                  element.m_size.y=size.y;
+            }
+
             if(!p_webview)
             {
-               p_webview=new Wnd_WebView(m_wnd_main, element.m_id);
+               p_webview=new Wnd_WebView(m_wnd_main, element.m_size, element.m_id);
                if(element.m_docked)
                   p_webview->GetDocking().Dock(element.m_docking_side);
             }
+            else
+            {
+               if(p_webview->GetDocking().Docked())
+                  p_webview->GetDocking().SetSize(element.m_size);
+               else
+                  p_webview->SetSize(element.m_size);
+            }
+
+            if(element.m_caption.has_value())
+               p_webview->GetDocking().SetHideCaption(*element.m_caption);
 
             if(element.m_source)
                p_webview->SetSource(element.m_source);
             else
                p_webview->SetURL(element.m_url, element.m_headers.m_headers);
+            return false;
+         }
+         else if(package=="close")
+         {
+            JSON_WebView_Close element;
+            JSON::ParseObject(element, string);
+
+            Wnd_WebView *p_webview{};
+            if(element.m_id)
+            {
+               p_webview=m_wnd_main.FindWebView(element.m_id);
+               if(p_webview)
+                  p_webview->Destroy();
+            }
             return false;
          }
          return false;
@@ -516,6 +582,10 @@ void Connection::Send(ConstString string, bool send_event, bool raw)
 
    if(!IsConnected())
    {
+      if(m_in_send)
+         return;
+
+      RestorerOf _(m_in_send); m_in_send=true; // To prevent infinite recursion since Receive calls triggers on the prompt text.
       Text(STR_HTML_NotConnected);
       if(m_ppropServer && MessageBox(m_wnd_main, STR_AskReconnect, STR_NotConnected, MB_ICONEXCLAMATION|MB_YESNO)==IDYES)
          Reconnect();
@@ -1064,7 +1134,7 @@ void Connection::Disconnected(DWORD error)
    Text(FixedStringBuilder<256>("<icon information> <font color='aqua'>Will try to reconnect in ", int(seconds), " seconds"));
 }
 
-OM::IWindow_Main *Connection::GetWindow_Main()
+OM::I::Window_Main *Connection::GetWindow_Main()
 {
    return m_wnd_main.GetDispatch();
 }
@@ -1166,16 +1236,7 @@ void Connection::Display(UniquePtr<Text::Line> &&p_line)
    if(m_propConnections.propTriggers().fActive())
    {
       for(unsigned i=0;i<m_multiline_triggers.Count();i++)
-      {
-         auto &multiline=*m_multiline_triggers[i];
-         RunTriggers(*p_line, multiline.mp_trigger->propTriggers(), state);
-         if(multiline.m_line_limit!=0 && ++multiline.m_line_count>=multiline.m_line_limit)
-         {
-            m_multiline_triggers.Delete(i--);
-            if(mp_trigger_debug)
-               TriggerDebugText("#000040", "blue", "10", "Multiline child triggers hit line limit");
-         }
-      }
+         RunTriggers(*p_line, m_multiline_triggers[i]->mp_trigger->propTriggers(), state);
 
       RunTriggers(*p_line, m_propConnections.propTriggers().Pre(), state);
 
@@ -1190,6 +1251,21 @@ void Connection::Display(UniquePtr<Text::Line> &&p_line)
       }
 
       RunTriggers(*p_line, m_propConnections.propTriggers().Post(), state);
+
+      // Delete empty and expired multiline triggers
+      for(unsigned i=0; i<m_multiline_triggers.Count(); i++)
+      {
+         auto &p_multiline=m_multiline_triggers[i];
+         if(p_multiline && p_multiline->m_line_limit!=0 && ++p_multiline->m_line_count>=p_multiline->m_line_limit)
+         {
+            p_multiline=nullptr;
+            if(mp_trigger_debug)
+               TriggerDebugText("#000040", "blue", "10", "Multiline child triggers hit line limit");
+         }
+
+         if(!p_multiline)
+            m_multiline_triggers.Delete(i--);
+      }
 
       // Add new multiline triggers to beginning of list, such that the last one added to the list will be first
       while(m_new_multiline_triggers)
@@ -1234,7 +1310,7 @@ void Connection::Display(UniquePtr<Text::Line> &&p_line)
       p_spawn_window=mp_captured_spawn_window;
       state.mp_spawn_trigger=mp_captured_spawn_window->mp_capture_until;
 
-      if(RegEx::Expression *p_regex=state.mp_spawn_trigger->propSpawn().GetCaptureUntilRegEx();p_regex && p_regex->Find(p_line->GetText(), 0).has_value())
+      if(RegEx::Expression *p_regex=state.mp_spawn_trigger->propSpawn().GetCaptureUntilRegEx();p_regex && p_regex->Find(p_line->GetText(), 0))
          KillSpawnCapture();
    }
 
@@ -1410,7 +1486,7 @@ void Connection::ShowSpawnCancel()
    mp_captureabort_window=MakeUnique<Wnd_CaptureAbort>(*this);
 }
 
-Color ColorHash(ConstString text, uint2 range, Array<const uint2> ranges, float brightness)
+Color ColorHash(ConstString text, uint2 range, Array<const size_t_2> ranges, float brightness)
 {
    if(range.end==0) // If whole line, use the first () range if it exists, otherwise the regular range
       range=ranges.Count()>1 ? ranges[1] : ranges[0];
@@ -1419,7 +1495,7 @@ Color ColorHash(ConstString text, uint2 range, Array<const uint2> ranges, float 
    return HSVtoRGB(float3((hash&0xFFF)/4095.0f, ((hash>>12)&0xFFF)/8190.0f+0.5f, brightness));
 };
 
-void ApplyParagraphToLine(const Prop::Trigger_Paragraph &p, Text::Line &line, Array<const uint2> ranges)
+void ApplyParagraphToLine(const Prop::Trigger_Paragraph &p, Text::Line &line, Array<const size_t_2> ranges)
 {
    if(p.fUseIndent_Left())
       line.SetIndentLeft(p.Indent_Left()/100.0f);
@@ -1524,7 +1600,7 @@ void Connection::RunTriggers(Text::Line &line, Array<CopyCntPtrTo<Prop::Trigger>
                   TriggerDebugText("#000040", "blue", "10", "Starting cooldown");
             }
 
-            static constexpr uint2 c_wholeLine[]={ uint2() };
+            static constexpr size_t_2 c_wholeLine[1];
 
             // Color
             if(ppropTrigger->fPropColor())
@@ -1905,7 +1981,7 @@ void Connection::RunTriggers(Text::Line &line, Array<CopyCntPtrTo<Prop::Trigger>
 
                // Look for existing trigger
                if(auto existing=FindMultiline(m_multiline_triggers, *ppropTrigger); existing!=~0U)
-                  m_new_multiline_triggers.Push(m_multiline_triggers.Delete(existing));
+                  m_new_multiline_triggers.Push(std::move(m_multiline_triggers[existing]));
                else if(auto existing=FindMultiline(m_new_multiline_triggers, *ppropTrigger); existing!=~0U)
                   m_new_multiline_triggers.Push(m_new_multiline_triggers.Delete(existing));
                else
@@ -2401,8 +2477,7 @@ uint2 Puppet::FindRegEx(const Prop::Puppet &propPuppet, ConstString string)
    if(!propPuppet.mp_regex_cache)
       propPuppet.mp_regex_cache=MakeUnique<RegEx::Expression>(propPuppet.pclReceivePrefix(), PCRE2_UTF);
 
-   FixedArray<uint2, 15> ranges_buffer;
-   auto ranges=propPuppet.mp_regex_cache->Find(string, 0, ranges_buffer);
+   auto ranges=propPuppet.mp_regex_cache->Find(string, 0);
    if(ranges.Count()==0)
       return {};
 

--- a/src/Connection.h
+++ b/src/Connection.h
@@ -141,7 +141,7 @@ struct Connection
 
    MCP::Parser *GetMCP_Parser() { return mp_MCP; }
    Wnd_Main &GetMainWindow() const { return m_wnd_main; }
-   OM::IWindow_Main *STDMETHODCALLTYPE GetWindow_Main();
+   OM::I::Window_Main *STDMETHODCALLTYPE GetWindow_Main();
 
    Time::Stopwatch m_ping_timer;
 

--- a/src/Connection_OM.cpp
+++ b/src/Connection_OM.cpp
@@ -153,7 +153,7 @@ STDMETHODIMP Connection::IsLogging(VARIANT_BOOL *retval)
    *retval=VariantBool(mp_connection->IsLogging()); return S_OK;
 }
 
-STDMETHODIMP Connection::get_World(IWorld **retval)
+STDMETHODIMP Connection::get_World(I::World **retval)
 {
    ZOMBIECHECK
    Prop::Server *pServer=mp_connection->GetServer();
@@ -162,7 +162,7 @@ STDMETHODIMP Connection::get_World(IWorld **retval)
    *retval=new World(*pServer); (*retval)->AddRef(); return S_OK;
 }
 
-STDMETHODIMP Connection::get_Character(ICharacter **retval)
+STDMETHODIMP Connection::get_Character(I::Character **retval)
 {
    ZOMBIECHECK
    Prop::Character *pCharacter=mp_connection->GetCharacter();
@@ -171,7 +171,7 @@ STDMETHODIMP Connection::get_Character(ICharacter **retval)
    *retval=new Character(*pCharacter); (*retval)->AddRef(); return S_OK;
 }
 
-STDMETHODIMP Connection::get_Puppet(IPuppet **retval)
+STDMETHODIMP Connection::get_Puppet(I::Puppet **retval)
 {
    ZOMBIECHECK
    Prop::Puppet *pPuppet=mp_connection->GetPuppet();
@@ -180,13 +180,13 @@ STDMETHODIMP Connection::get_Puppet(IPuppet **retval)
    *retval=new Puppet(*pPuppet); (*retval)->AddRef(); return S_OK;
 }
 
-STDMETHODIMP Connection::get_Window_Main(IWindow_Main **retval)
+STDMETHODIMP Connection::get_Window_Main(I::Window_Main **retval)
 {
    ZOMBIECHECK
    return RefReturner(retval)(mp_connection->GetWindow_Main());
 }
 
-STDMETHODIMP Connection::get_Log(ILog **retval)
+STDMETHODIMP Connection::get_Log(I::Log **retval)
 {
    ZOMBIECHECK
    auto *p_log=mp_connection->GetAutoLog();

--- a/src/Connection_OM.h
+++ b/src/Connection_OM.h
@@ -4,14 +4,14 @@ namespace OM
 {
 
 struct Connection
-:  Dispatch<IConnection>,
+:  Dispatch<I::Connection>,
    Events::ReceiversOf<Connection, ::Connection::Event_Receive, ::Connection::Event_Display,
       ::Connection::Event_Connect, ::Connection::Event_Disconnect, ::Connection::Event_Send,
       ::Connection::Event_GMCP, ::Connection::Event_Log>
 {
    Connection(::Connection *pConnection);
 
-   USE_INHERITED_UNKNOWN(IConnection)
+   USE_INHERITED_UNKNOWN(I::Connection)
 
    // IUnknown
    STDMETHODIMP QueryInterface(REFIID riid, void **ppvObj);
@@ -35,11 +35,11 @@ struct Connection
    STDMETHODIMP Reconnect(VARIANT_BOOL *retval);
    STDMETHODIMP IsLogging(VARIANT_BOOL *retval);
 
-   STDMETHODIMP get_World(IWorld **);
-   STDMETHODIMP get_Character(ICharacter **);
-   STDMETHODIMP get_Puppet(IPuppet **);
-   STDMETHODIMP get_Window_Main(IWindow_Main **);
-   STDMETHODIMP get_Log(ILog **);
+   STDMETHODIMP get_World(I::World **);
+   STDMETHODIMP get_Character(I::Character **);
+   STDMETHODIMP get_Puppet(I::Puppet **);
+   STDMETHODIMP get_Window_Main(I::Window_Main **);
+   STDMETHODIMP get_Log(I::Log **);
 
    // Events
    void On(::Connection::Event_Receive &event);

--- a/src/Dlg_KeyboardMacros.cpp
+++ b/src/Dlg_KeyboardMacros.cpp
@@ -203,16 +203,6 @@ bool Dlg::EditKey(const Msg::Key &msg)
    if(msg.direction()==Direction::Up) return true;
    auto iVKey=msg.iVirtKey();
 
-   // Only allow certain keys
-   // F-Keys, A-Z, 0-9
-   if((iVKey<VK_F1 || iVKey>VK_F24) && (iVKey<'A' || iVKey>'Z') && (iVKey<'0' || iVKey>'9') &&
-      (iVKey<VK_NUMPAD0 || iVKey>VK_NUMPAD9) &&
-      (iVKey!=VK_TAB && iVKey!=VK_PAUSE && iVKey!=VK_SPACE && iVKey!=VK_HOME &&
-       iVKey!=VK_UP && iVKey!=VK_DOWN && iVKey!=VK_LEFT && iVKey!=VK_RIGHT &&
-       iVKey!=VK_ADD && iVKey!=VK_SUBTRACT && iVKey!=VK_MULTIPLY && iVKey!=VK_DIVIDE &&
-       iVKey!=VK_DECIMAL && iVKey!=VK_OEM_1 /* ; */ && iVKey!=VK_OEM_PLUS))
-      return false;
-
    m_iVKey=iVKey;
 
    KEY_ID key; // Temporary Key so we can update the display

--- a/src/Dlg_Triggers.cpp
+++ b/src/Dlg_Triggers.cpp
@@ -8,7 +8,7 @@
 #include "FindString.h"
 #include "Matcharoo.h"
 
-void ApplyParagraphToLine(const Prop::Trigger_Paragraph &p, Text::Line &line, Array<const uint2> ranges);
+void ApplyParagraphToLine(const Prop::Trigger_Paragraph &p, Text::Line &line, Array<const size_t_2> ranges);
 
 namespace
 {

--- a/src/FindString.cpp
+++ b/src/FindString.cpp
@@ -5,14 +5,15 @@
 #include "FindString.h"
 
 FindStringSearch::FindStringSearch(const Prop::FindString &fs, ConstString string)
-: m_fs(fs), m_string(string)
+   : m_fs{fs}, m_string{string}, m_ranges{&fs.m_search_range, 1}
 {
+   fs.m_search_range={};
 }
 
 bool FindStringSearch::Next()
 {
-   m_rangeCount=m_fs.Find(m_string, m_ranges[0].end, m_ranges).Count();
-   if(m_rangeCount==0)
+   m_ranges=m_fs.Find(m_string, m_ranges[0].end);
+   if(!m_ranges)
       return false;
    
    if(m_ranges[0].end==m_ranges[0].begin)
@@ -63,8 +64,23 @@ FindStringReplacement::FindStringReplacement(const FindStringSearch &search, Con
       if(replace.Count()<2)
          break;
 
-      char c=replace[1];
-      if(unsigned value=c-'0'; value<ranges.Count())
+      unsigned value=0;
+      unsigned value_length=2;
+      if(replace[1]=='a') // \a## (4 character code)
+      {
+         // Grab the next two chars as two digit number
+         if(replace.Count()<4)
+            break;
+
+         value=(replace[2]-'0')*10+(replace[3]-'0');
+         value_length=4;
+      }
+      else // \# (2 character code)
+      {
+         value=replace[1]-'0';
+      }
+
+      if(value<ranges.Count())
       {
          auto sub=search.SearchString().Sub(ranges[value]);
          if(escape_html)
@@ -74,15 +90,16 @@ FindStringReplacement::FindStringReplacement(const FindStringSearch &search, Con
       }
       else
       {
-         m_replacement('\\');
-         if(c!='\\') // Not an escaped slash?  Then echo the char
-            m_replacement(c);
+         if(replace[1]=='\\') // An escaped slash?
+            m_replacement('\\');
+         else // Invalid sequence, so just display whatever it was
+            m_replacement(replace.First(value_length));
       }
 
-      replace=replace.WithoutFirst(2);
+      replace=replace.WithoutFirst(value_length);
       slash_index=replace.FindFirstOf('\\', replace.Count());
    }
-
+   m_replacement(replace);
    ConstString::operator=(m_replacement);
 }
 

--- a/src/FindString.h
+++ b/src/FindString.h
@@ -8,7 +8,7 @@ struct FindStringSearch
 
    bool Next();
 
-   Array<const uint2> ranges() const { return m_ranges.First(m_rangeCount); }
+   Array<const size_t_2> ranges() const { return m_ranges; }
 
    const uint2 RangeFound() const { return m_ranges[0]; }
    unsigned Start() const { return m_ranges[0].begin; }
@@ -30,8 +30,7 @@ private:
    ConstString m_string;
    bool m_empty_seen{}; // If we ever match on nothing, we need to find nothing the second time through, or we'll loop forever
 
-   FixedArray<uint2, 15> m_ranges;
-   unsigned m_rangeCount{}; // Number of ranges filled in by the RegExFind() function
+   Array<size_t_2> m_ranges;
 };
 
 struct FindStringReplacement : ConstString

--- a/src/Main.cpp
+++ b/src/Main.cpp
@@ -1,5 +1,6 @@
 #include "Main.h"
 #include "Automation.h"
+#include <Shobjidl_core.h>
 #pragma comment(lib, "gdi32")
 #pragma comment(lib, "comdlg32")
 #pragma comment(lib, "shell32")
@@ -90,6 +91,9 @@ void GlobalEvents::InitNewDayTimer()
 
 int WINAPI wWinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, wchar_t *pCmdLine, int nCmdShow)
 {
+   if(!IsStoreApp())
+      SetCurrentProcessExplicitAppUserModelID(L"R-Axis.BeipMU");
+
    g_random.SeedRandomDevice();
    SetGenerateMinidumpOnCrash();
 

--- a/src/Main.h
+++ b/src/Main.h
@@ -21,13 +21,13 @@
 #define YARN 1
 #define DWRITE_TEST 1
 #else
-#define BETA_BUILD 2
+#define BETA_BUILD 1
 #define SCRIPTING 0
 #define YARN 0
 #define DWRITE_TEST 0
 #endif
 
-namespace OM
+namespace OM::I
 {
 #include "OM.h"
 };
@@ -88,6 +88,8 @@ struct ErrorCollection : IError, Collection<OwnedString>
 void ConsoleHTML(ConstString string);
 void ConsoleText(ConstString string);
 void ConsoleDelete();
+
+UniquePtr<Text::Line> CreateLineInternal(ConstString string);
 
 #include "RegEx.h"
 #include "WinFunc.h"

--- a/src/OM.idl
+++ b/src/OM.idl
@@ -18,15 +18,15 @@ library BeipMU
    importlib("stdole32.tlb");
    #include "OM_Props.idl"
 
-   interface IConnection;
-   interface IWindow_Main;
-   interface ITextWindowLine;
+   interface Connection;
+   interface Window_Main;
+   interface TextWindowLine;
 
    [ uuid(4be9e159-9074-446c-9fa3-c08fc97c5502), oleautomation, dual, nonextensible ]
-   interface IWindow_Properties : IDispatch
+   interface Window_Properties : IDispatch
    {
-      [propput] HRESULT Title([in] BSTR title);
       [propget] HRESULT Title([out, retval] BSTR *title);
+      [propput] HRESULT Title([in] BSTR title);
 
       [propget] HRESULT HWND([out, retval] __int3264 *hwnd);
    }
@@ -39,57 +39,58 @@ library BeipMU
    } MouseButton;
 
    [ uuid(7401476A-2852-487f-9B4A-22927B1EC320), oleautomation, dual, nonextensible ]
-   interface IWindow_Events : IDispatch
+   interface Window_Events : IDispatch
    {
-      HRESULT SetOnClose([in, defaultvalue(0)] IDispatch *pDisp, [in, defaultvalue(0)] VARIANT var);
-      HRESULT SetOnMouseMove([in, defaultvalue(0)] IDispatch *pDisp, [in, defaultvalue(0)] VARIANT var);
+      HRESULT SetOnClose([in, defaultvalue(0)] IDispatch *OnClose, [in, defaultvalue(0)] VARIANT userdata);
+      HRESULT SetOnMouseMove([in, defaultvalue(0)] IDispatch *OnMouseMove, [in, defaultvalue(0)] VARIANT userdata);
       // OnMouseMove(x, y)
-      HRESULT SetOnKey([in, defaultvalue(0)] IDispatch *pDisp, [in, defaultvalue(0)] VARIANT var);
+      HRESULT SetOnKey([in, defaultvalue(0)] IDispatch *OnKey, [in, defaultvalue(0)] VARIANT userdata);
       // OnKey(key)
-//      HRESULT SetOnMouseButton([in, defaultvalue(0)] IDispatch *pDisp, [in, defaultvalue(0)] VARIANT var);
+//      HRESULT SetOnMouseButton([in, defaultvalue(0)] IDispatch *pDisp, [in, defaultvalue(0)] VARIANT userdata);
       // OnMouseButton(x,y,button)
    }
 
    [uuid(AA9E1802-71D0-4E53-8E6E-2FD4A1326B97), oleautomation, dual, nonextensible]
-   interface IArrayUInt : IDispatch
+   interface ArrayUInt : IDispatch
    {
-      [propget, id(DISPID_VALUE)] HRESULT Item([in] VARIANT var, [out, retval] unsigned int *retval);
+      [propget, id(DISPID_VALUE)] HRESULT Item([in] VARIANT index, [out, retval] unsigned int *retval);
       [propget] HRESULT Count([out, retval] long *);
    }
 
    [ uuid(36A385C6-A258-4210-A61C-EB3890501903), oleautomation, dual, nonextensible ]
-   interface ITextWindowLine : IDispatch
+   interface TextWindowLine : IDispatch
    {
       [propget] HRESULT Length([out, retval] long *);
       [propget] HRESULT String([out, retval] BSTR *); 
       [propget] HRESULT HTMLString([out, retval] BSTR *);
 
-      HRESULT Insert([in] unsigned int position, [in] ITextWindowLine *line);
+      HRESULT Insert([in] unsigned int position, [in] TextWindowLine *line);
       HRESULT Delete([in] unsigned int start, [in] unsigned int end);
 
-      HRESULT Color([in] unsigned int start, [in] unsigned int end, [in, defaultvalue(0)] long lColor);
-      HRESULT BgColor([in] unsigned int start, [in] unsigned int end, [in, defaultvalue(0)] long lColor);
+      HRESULT Color([in] unsigned int start, [in] unsigned int end, [in, defaultvalue(0)] long color);
+      HRESULT BgColor([in] unsigned int start, [in] unsigned int end, [in, defaultvalue(0)] long color);
 
-      HRESULT Bold([in] unsigned int start, [in] unsigned int end, [in, defaultvalue(1)] VARIANT_BOOL fSet);
-      HRESULT Italic([in] unsigned int start, [in] unsigned int end, [in, defaultvalue(1)] VARIANT_BOOL fSet);
-      HRESULT Underline([in] unsigned int start, [in] unsigned int end, [in, defaultvalue(1)] VARIANT_BOOL fSet);
-      HRESULT Strikeout([in] unsigned int start, [in] unsigned int end, [in, defaultvalue(1)] VARIANT_BOOL fSet);
-      HRESULT Flash([in] unsigned int start, [in] unsigned int end, [in, defaultvalue(1)] VARIANT_BOOL fSet);
-      HRESULT FlashMode([in] unsigned int start, [in] unsigned int end, [in, defaultvalue(0)] int iMode); // 0 = normal, 1 = inverse
+      HRESULT Bold([in] unsigned int start, [in] unsigned int end, [in, defaultvalue(1)] VARIANT_BOOL set);
+      HRESULT Italic([in] unsigned int start, [in] unsigned int end, [in, defaultvalue(1)] VARIANT_BOOL set);
+      HRESULT Underline([in] unsigned int start, [in] unsigned int end, [in, defaultvalue(1)] VARIANT_BOOL set);
+      HRESULT Strikeout([in] unsigned int start, [in] unsigned int end, [in, defaultvalue(1)] VARIANT_BOOL set);
+      HRESULT Flash([in] unsigned int start, [in] unsigned int end, [in, defaultvalue(1)] VARIANT_BOOL set);
+      [helpstring("mode: 0 = normal, 1 = inverse")]
+      HRESULT FlashMode([in] unsigned int start, [in] unsigned int end, [in, defaultvalue(0)] int mode);
       HRESULT Blink([in] unsigned int start, [in] unsigned int end, [in] unsigned int iBits, [in] unsigned int mask);
    }
 
     [ uuid(36A385C4-A258-4210-A61C-EB3890501903), dual, nonextensible ]
-   interface IWindow_Text : IDispatch
+   interface Window_Text : IDispatch
    {
-      [propget] HRESULT Properties([out, retval] IWindow_Properties **retval);
-      [propget] HRESULT Paused([out, retval] VARIANT_BOOL *paused);
+      [propget] HRESULT Properties([out, retval] Window_Properties **retval);
+      [propget] HRESULT Paused([out, retval] VARIANT_BOOL *);
 
-      HRESULT Create([in] BSTR bstr, [out, retval] ITextWindowLine** retval);
-      HRESULT CreateHTML([in] BSTR bstr, [out, retval] ITextWindowLine** retval);
-      HRESULT Add([in] ITextWindowLine *lineNew);
-      HRESULT Write([in] BSTR bstr);
-      HRESULT WriteHTML([in] BSTR bstr);
+      HRESULT Create([in] BSTR text, [out, retval] TextWindowLine** retval);
+      HRESULT CreateHTML([in] BSTR html, [out, retval] TextWindowLine** retval);
+      HRESULT Add([in] TextWindowLine *line);
+      HRESULT Write([in] BSTR text);
+      HRESULT WriteHTML([in] BSTR html);
 
       HRESULT SetOnPause([in, defaultvalue(0)] IDispatch *pDisp);
 
@@ -98,14 +99,14 @@ library BeipMU
    }
 
    [ uuid(9D4D0B72-ABAD-40C7-91E6-29B07F6DC721), oleautomation, dual, nonextensible ]
-   interface IWindow_SpawnTabs : IDispatch
+   interface Window_SpawnTabs : IDispatch
    {
-      HRESULT SetOnTabActivate([in, defaultvalue(0)] IDispatch *pDisp, [in, defaultvalue(0)] VARIANT var);
+      HRESULT SetOnTabActivate([in, defaultvalue(0)] IDispatch *OnTabActivate, [in, defaultvalue(0)] VARIANT userdata);
       // OnTabActivate(BSTR tab_name, var);
    }
 
    [ uuid(E50E3B98-5AE1-4fe7-814A-4B1B1A188EF2), oleautomation, dual, nonextensible ]
-   interface IWindow_Input : IDispatch
+   interface Window_Input : IDispatch
    {
       HRESULT SetSel([in] int start, [in] int end);
       HRESULT GetSelStart([out, retval] int *retval);
@@ -114,55 +115,80 @@ library BeipMU
       [propget] HRESULT Length([out, retval] int *retval);
 
       [propget] HRESULT Prefix([out, retval] BSTR *retval);
-      [propput] HRESULT Prefix([in] BSTR bstr);
+      [propput] HRESULT Prefix([in] BSTR text);
       [propget] HRESULT Title([out, retval] BSTR *retval);
-      [propput] HRESULT Title([in] BSTR bstr);
+      [propput] HRESULT Title([in] BSTR text);
 
       HRESULT Set([in] BSTR bstr);
       HRESULT Get([out, retval] BSTR *retval);
    }
 
    [ uuid(479a8e11-1a05-464d-afec-6c32a7a3a3b5), oleautomation, dual, nonextensible ]
-   interface ILog : IDispatch
+   interface Log : IDispatch
    {
-      HRESULT Write([in] BSTR bstr);
-      HRESULT WriteLine([in] ITextWindowLine *pLine);
+      HRESULT Write([in] BSTR text);
+      HRESULT WriteLine([in] TextWindowLine *line);
 
-      [propget] HRESULT FileName([out, retval] BSTR *bstr);
+      [propget] HRESULT FileName([out, retval] BSTR *);
    }
 
    [ uuid(36A385C5-A258-4210-A61C-EB3890501903), oleautomation, dual, nonextensible ]
-   interface IConnection : IDispatch
+   interface Connection : IDispatch
    {
-      HRESULT Send([in] BSTR bstr); // Text about to be sent
-      HRESULT SetOnSend([in, defaultvalue(0)] IDispatch *pDisp, [in, defaultvalue(0)] VARIANT var);
-      // OnSend(bstr Text, var);
-      HRESULT Transmit([in] BSTR bstr); // Send the text to the connection
+      HRESULT Send([in] BSTR text); // Text about to be sent
+      [helpstring("Set the OnSend callback which is called when text is about to be sent over the network\n"
+         "\n"
+         "Callback function signature:\n"
+         "  void OnSend(string text, var userdata)")]
+      HRESULT SetOnSend([in, defaultvalue(0)] IDispatch *OnSend, [in, defaultvalue(0)] VARIANT userdata);
+      [helpstring("Translates 'text' to the server's text encoding and sends it over the network")]
+      HRESULT Transmit([in] BSTR text);
 
-      HRESULT Receive([in] BSTR bstr); // Act as though the given string was received from the connection
-      HRESULT SetOnReceive([in, defaultvalue(0)] IDispatch *pDisp, [in, defaultvalue(0)] VARIANT var);
-      // OnReceive(bstr Text, var);
+      [helpstring("Receive data as though the given string was received from the connection (in the server's text encoding). Processes telnet codes and then divides the resulting text into single lines that it will pass to Display()")]
+      HRESULT Receive([in] BSTR text);
+      [helpstring("Set the OnReceive callback which is called when text is received from the network (or by Receive being called)\n"
+         "\n"
+         "Callback function signature:\n"
+         "  void OnReceive(string text, var userdata)")]
+      HRESULT SetOnReceive([in, defaultvalue(0)] IDispatch *OnReceive, [in, defaultvalue(0)] VARIANT userdata);
 
-      HRESULT Display([in] BSTR bstr); // 
-      HRESULT SetOnDisplay([in, defaultvalue(0)] IDispatch *pDisp, [in, defaultvalue(0)] VARIANT var);
-      // OnDisplay(ITextWindowLine, var);
+      [helpstring("Parse a line of text for display (text is still in server's text encoding). Handles HTML/triggers/puppets/etc")]
+      HRESULT Display([in] BSTR text);
+      [helpstring("Set the OnDisplay callback which is called when a line of text is about to be displayed\n"
+         "\n"
+         "Callback function signature:\n"
+         "  void OnDisplay(ITextWindowLine line, var userdata)")]
+      HRESULT SetOnDisplay([in, defaultvalue(0)] IDispatch *OnDisplay, [in, defaultvalue(0)] VARIANT userdata);
 
-      HRESULT SetOnGMCP([in, defaultvalue(0)] IDispatch *pDisp, [in, defaultvalue(0)] VARIANT var);
+      [helpstring("Set a callback for when an OOB GMCP message is received. The 'text' is the raw message, not split into tag/json\n"
+         "\n"
+         "Callback function signature:\n"
+         "  void OnGMCP(string text, var userdata)")]
+      HRESULT SetOnGMCP([in, defaultvalue(0)] IDispatch *OnGMCP, [in, defaultvalue(0)] VARIANT userdata);
 
-      HRESULT SetOnConnect([in, defaultvalue(0)] IDispatch *pDisp, [in, defaultvalue(0)] VARIANT var);
-      HRESULT SetOnDisconnect([in, defaultvalue(0)] IDispatch *pDisp, [in, defaultvalue(0)] VARIANT var);
+      [helpstring("Set a callback for when a connection is made\n"
+         "\n"
+         "Callback function signature:\n"
+         "  void OnConnect(var userdata)")]
+      HRESULT SetOnConnect([in, defaultvalue(0)] IDispatch *OnConnect, [in, defaultvalue(0)] VARIANT userdata);
+      [helpstring("Set a callback for when a disconnection happens\n"
+         "\n"
+         "Callback function signature:\n"
+         "  void OnDisconnect(var userdata)")]
+      HRESULT SetOnDisconnect([in, defaultvalue(0)] IDispatch *OnDisconnect, [in, defaultvalue(0)] VARIANT userdata);
 
       HRESULT IsConnected([out, retval] VARIANT_BOOL *);
+      [helpstring("Tries to reconnect to the last server, returns true if successful. Failure is likely due to no last server or if we're already connected.")]
       HRESULT Reconnect([out, retval] VARIANT_BOOL *); // Returns TRUE if reconnect possible
 
       HRESULT IsLogging([out, retval] VARIANT_BOOL *);
-      [propget] HRESULT Log([out, retval] ILog **);
+      [propget] HRESULT Log([out, retval] Log **);
 
-      [propget] HRESULT World([out, retval] IWorld **);
-      [propget] HRESULT Character([out, retval] ICharacter **);
-      [propget] HRESULT Puppet([out, retval] IPuppet **);
+      [propget, helpstring("Currnet world (or null if there is no current world)")] HRESULT World([out, retval] World **);
+      [propget, helpstring("Current character (or null if there is no current character)")] HRESULT Character([out, retval] Character **);
+      [propget, helpstring("Current puppet (or null if there is no current puppet")] HRESULT Puppet([out, retval] Puppet **);
 
-      [propget] HRESULT Window_Main([out, retval] IWindow_Main **retval);
+      [propget] HRESULT Window_Main([out, retval] Window_Main **retval);
    }
 
    typedef enum tagSide
@@ -174,40 +200,45 @@ library BeipMU
    } Side;
 
    [ uuid(39ac8829-0e73-40d7-bec7-193c72e2a7cc), oleautomation, dual, nonextensible ]
-   interface IDocking : IDispatch
+   interface Docking : IDispatch
    {
       HRESULT Dock(Side side); // Docks the window to a particular side
    };
 
-   [ uuid(36A385C1-A258-4210-A61C-EB3890501903), oleautomation, dual, nonextensible ]
-   interface IWindow_Main : IDispatch
+   [ uuid(36A385C1-A258-4210-A61C-EB3890501903), oleautomation, dual, nonextensible,
+     helpstring("This is the main window (the tabs on the BeipMU taskbar are each one of these)")
+   ]
+   interface Window_Main : IDispatch
    {
-      [propget] HRESULT Output([out, retval] IWindow_Text** retval);
-      [propget] HRESULT History([out, retval] IWindow_Text** retval);
-      [propget] HRESULT Input([out, retval] IWindow_Input** retval); // Gets the default input window
-      [propget] HRESULT Connection([out, retval] IConnection** retval);
+      [propget] HRESULT Output([out, retval] Window_Text **retval);
+      [propget] HRESULT History([out, retval] Window_Text** retval);
+      [propget] HRESULT Input([out, retval] Window_Input** retval); // Gets the default input window
+      [propget] HRESULT Connection([out, retval] Connection** retval);
 
       [propget] HRESULT UserData([out, retval] VARIANT *pVar);
       [propput] void UserData([in] VARIANT var);
 
-      HRESULT GetInput([in] BSTR title, [out, retval] IWindow_Input **retval); // Gets secondary input windows by name
-      HRESULT GetSpawnTabs([in] BSTR title, [out, retval] IWindow_SpawnTabs **retval); // Get spawn tabs window by name
+      HRESULT GetInput([in] BSTR title, [out, retval] Window_Input **retval); // Gets secondary input windows by name
+      HRESULT GetSpawnTabs([in] BSTR title, [out, retval] Window_SpawnTabs **retval); // Get spawn tabs window by name
 
       HRESULT Close();
 
-      HRESULT SetOnCommand([in, defaultvalue(0)] IDispatch *pDisp, [in, defaultvalue(0)] VARIANT var);
-      HRESULT SetOnActivate([in, defaultvalue(0)] IDispatch *pDisp, [in, defaultvalue(0)] VARIANT var);
+      HRESULT SetOnCommand([in, defaultvalue(0)] IDispatch *OnCommand, [in, defaultvalue(0)] VARIANT userdata);
+      HRESULT SetOnActivate([in, defaultvalue(0)] IDispatch *OnActivate, [in, defaultvalue(0)] VARIANT userdata);
       // OnActivate(ISocket sock, BSTR bstrData);
-      HRESULT SetOnClose([in, defaultvalue(0)] IDispatch *pDisp, [in, defaultvalue(0)] VARIANT var);
+      HRESULT SetOnClose([in, defaultvalue(0)] IDispatch *OnClose, [in, defaultvalue(0)] VARIANT userdata);
 
-      HRESULT Run([in] BSTR bstr);
-      HRESULT RunFile([in] BSTR bstr);
+      HRESULT Run([in] BSTR command);
+      HRESULT RunFile([in] BSTR filename);
 
       HRESULT CreateDialogConnect(); // Fails if window is already connected
 
-      [propput] HRESULT TitlePrefix([in] BSTR title); // Sets the title prefix (what appears before BeipMU's automatic title)
       [propget] HRESULT TitlePrefix([out, retval] BSTR *title);
+      [propput] HRESULT TitlePrefix([in] BSTR title); // Sets the title prefix (what appears before BeipMU's automatic title)
       [propget] HRESULT Title([out, retval] BSTR *title); // Reads the current full title
+
+      [helpstring("Show activity on this tab")] HRESULT Activity();
+      [helpstring("Add important activity on this tab")] HRESULT AddImportantActivity();
 
       HRESULT GetVariable([in] BSTR name, [out, retval] BSTR *value);
       HRESULT SetVariable([in] BSTR name, [in] BSTR value);
@@ -215,29 +246,29 @@ library BeipMU
    }
 
    [ uuid(E9440711-EB4F-4250-AE95-5DB339E27C98), oleautomation, dual, nonextensible ]
-   interface IWindows : IDispatch
+   interface Windows : IDispatch
    {
-      [propget, id(DISPID_VALUE)] HRESULT Item([in] VARIANT var, [out, retval] IWindow_Main** retval);
+      [propget, id(DISPID_VALUE)] HRESULT Item([in] VARIANT var, [out, retval] Window_Main** retval);
       [propget] HRESULT Count([out, retval] long *);
    }
 
    [ uuid(9B7F5272-55B2-43ef-9E46-545F8D866AD8), oleautomation, dual, nonextensible ]
-   interface IWindow_FixedText : IDispatch
+   interface Window_FixedText : IDispatch
    {
-      [propget] HRESULT Events([out, retval] IWindow_Events **retval);
-      [propget] HRESULT Properties([out, retval] IWindow_Properties **retval);
+      [propget] HRESULT Events([out, retval] Window_Events **retval);
+      [propget] HRESULT Properties([out, retval] Window_Properties **retval);
 
-      [propput] HRESULT CursorX([in] int X);
       [propget] HRESULT CursorX([out, retval] int *pX);
-      [propput] HRESULT CursorY([in] int Y);
+      [propput] HRESULT CursorX([in] int X);
       [propget] HRESULT CursorY([out, retval] int *pY);
+      [propput] HRESULT CursorY([in] int Y);
 
       HRESULT Clear();
       HRESULT Write([in] BSTR);
    }
 
    [ uuid(2531C240-64EA-4293-B08A-A9C1F9271627), oleautomation, dual, nonextensible ]
-   interface ITimer : IDispatch
+   interface Timer : IDispatch
    {
       [propget] HRESULT UserData([out, retval] VARIANT *pVar);
       [propput] void UserData([in] VARIANT var);
@@ -247,10 +278,10 @@ library BeipMU
    }
 
    [ uuid(71569D4A-704F-4fb3-8F18-CE0E0EE634F3), oleautomation, dual, nonextensible ]
-   interface IWindow_Graphics : IDispatch
+   interface Window_Graphics : IDispatch
    {
-      [propget] HRESULT Events([out, retval] IWindow_Events **retval);
-      [propget] HRESULT Properties([out, retval] IWindow_Properties **retval);
+      [propget] HRESULT Events([out, retval] Window_Events **retval);
+      [propget] HRESULT Properties([out, retval] Window_Properties **retval);
 
       [propget] HRESULT Width([out, retval] int *);
       [propget] HRESULT Height([out, retval] int *);
@@ -268,7 +299,7 @@ library BeipMU
    }
 
    [ uuid(06815526-b219-411c-bf00-afe01930db8b), oleautomation, dual, nonextensible ]
-   interface ISocket : IDispatch
+   interface Socket : IDispatch
    {
       HRESULT Connect([in] BSTR host, [in, defaultvalue(1234)] unsigned int iPort);
       HRESULT Close();
@@ -292,115 +323,138 @@ library BeipMU
    }
 
    [ uuid(1942893B-C4F0-410D-8348-D69DE3174CFB), dual, nonextensible ]
-   interface IWebView : IDispatch
+   interface WebView : IDispatch
    {
       HRESULT CloseWindow();
 
       HRESULT IsConnected([out, retval] VARIANT_BOOL *retval);
-      HRESULT SetOnConnect([in] IDispatch *p_callback);
-      HRESULT SetOnDisconnect([in] IDispatch *p_callback);
+      [helpstring("Callback function signature: void OnConnect()")]
+      HRESULT SetOnConnect([in] IDispatch *OnConnect);
+      [helpstring("Callback function signature: void OnDisconnect()")]
+         HRESULT SetOnDisconnect([in] IDispatch *OnDisconnect);
 
       HRESULT Send([in] BSTR bstr, [in, defaultvalue(0)] VARIANT_BOOL process_aliases); // Send the given string as text over the socket
+      [helpstring("Called right before text is sent to the server\n"
+         "Callback function signature: void OnSend(string text_sent)")]
       HRESULT SetOnSend([in] IDispatch *p_callback);
-      // OnSend(text);
 
       HRESULT Receive([in] BSTR bstr); // Act as though the given string was received from the connection
-      HRESULT SetOnReceive([in] IDispatch *p_callback);
-      // OnReceive(text);
+      [helpstring("Called when text is received (before being displayed)\n"
+         "Callback function signature: void OnReceive(string text_received)")]
+         HRESULT SetOnReceive([in] IDispatch *p_callback);
 
       HRESULT Display([in] BSTR bstr);
+      [helpstring("Register a callback to call when text is about to be displayed. The regex filters which lines reach the callback. Gag will cause the line to not be displayed in the UI.\n"
+         "Callback function signature: void OnDisplay(int id, ITextWindowLine line)")]
       HRESULT SetOnDisplay([in] int id, [in] IDispatch *p_callback, [in] BSTR regex, [in, defaultvalue(0)] VARIANT_BOOL gag);
       HRESULT ClearOnDisplay([in] int id);
-      // OnDisplay(line, matches)
 
-      HRESULT SetOnDisplayCapture([in] int id, [in] IDispatch *p_capture, [in] IDispatch *p_capture_changed, [in] BSTR regex_begin, [in] BSTR regex_end);
+      [helpcontext(1)]
+      HRESULT SetOnDisplayCapture([in] int id, [in] IDispatch *OnCapture, [in] IDispatch *OnCaptureChanged, [in] BSTR regex_begin, [in] BSTR regex_end);
       HRESULT ClearOnDisplayCapture([in] int id, [out, retval] VARIANT_BOOL *success);
-      // OnDisplayCapture(id, line)
-      // OnDisplayCaptureChanged(id, line, bool starting)
 
       HRESULT SendGMCP([in] BSTR package, [in] BSTR json);
-      HRESULT SetOnGMCP([in] BSTR package_prefix, [in] IDispatch *p_callback);
+      [helpstring("Adds the callback and the package_prefix to the list of GMCP handlers. When a GMCP message is received, if a prefix matches it will call the given callback.\n"
+         "Callback function signature: void OnGMCP(string package, string json)")]
+      HRESULT SetOnGMCP([in] BSTR package_prefix, [in] IDispatch *OnGMCP);
+      [helpstring("Removes the callback with package_prefix from the list of GMCP handlers.")]
       HRESULT ClearOnGMCP([in] BSTR package_prefix);
-      // OnGMCP(BSTR package, BSTR json)
 
       HRESULT ProcessAliases([in] BSTR text, [out, retval] BSTR *result);
       HRESULT AddToInputHistory([in] BSTR text);
+
+      [helpstring("Gets a string property from the webview. Here's the list of available properties:\n"
+         "WorldName - Name of current world\n"
+         "CharacterName - Name of current character\n"
+         "PuppetName - Name of current puppet\n"
+         "ID - ID the webview was created with")]
       HRESULT GetPropertyString([in] BSTR property, [out, retval] BSTR *result);
    }
 
    [ uuid(5b53fd39-46a8-4519-86a4-0442d98d79aa), oleautomation, dual, nonextensible ]
-   interface ISocketServer : IDispatch
+   interface SocketServer : IDispatch
    {
       HRESULT Shutdown();
       // OnConnection(ISocket sock);
    }
 
    [ uuid(334038f2-b7e7-4a0d-af86-eca67b6f82ff), oleautomation, dual, nonextensible ]
-   interface IReverseDNS : IDispatch
+   interface ReverseDNS : IDispatch
    {
       // The object created during a RevereDNS lookup (hidden currently)
    };
 
    [ uuid(daae34c6-1e89-410e-a095-eb1f8c2777a7), oleautomation, dual, nonextensible ]
-   interface IForwardDNS : IDispatch
+   interface ForwardDNS : IDispatch
    {
       // The object created during a ForwardDNS lookup (hidden currently)
    };
 
    [ uuid(36A385C8-A258-4210-A61C-EB3890501903), oleautomation, dual, nonextensible ]
-   interface IApp : IDispatch
+   interface App : IDispatch
    {
       [propget] HRESULT BuildNumber([out, retval] long *);
       [propget] HRESULT BuildDate([out, retval] DATE *);
       [propget] HRESULT Version([out, retval] long *);
 
-      [propget] HRESULT Worlds([out, retval] IWorlds **retval);
-      [propget] HRESULT Windows([out, retval] IWindows **retval);
-      [propget] HRESULT Triggers([out, retval] ITriggers **retval);
-      [propget] HRESULT Aliases([out, retval] IAliases **retval);
+      [propget] HRESULT Worlds([out, retval] Worlds **retval);
+      [propget] HRESULT Windows([out, retval] Windows **retval);
+      [propget] HRESULT Triggers([out, retval] Triggers **retval);
+      [propget] HRESULT Aliases([out, retval] Aliases **retval);
 
       [propget] HRESULT ConfigPath([out, retval] BSTR *retval);
 
       HRESULT ActiveXObject([in] BSTR name, [out, retval] IDispatch **retval);
 
-      HRESULT NewTrigger([out, retval] ITrigger **retval);
+      HRESULT NewTrigger([out, retval] Trigger **retval);
 
-      HRESULT NewWindow_FixedText([in, defaultvalue(80)] int iWidth, [in, defaultvalue(25)] int iHeight, [out, retval] IWindow_FixedText** retval);
-      HRESULT NewWindow_Graphics([in] int iWidth, [in] int iHeight, [out, retval] IWindow_Graphics** retval);
-      HRESULT NewWindow_Text([in, defaultvalue(320)] int iWidth, [in, defaultvalue(240)] int iHeight, [out, retval] IWindow_Text** retval);
+      HRESULT NewWindow_FixedText([in, defaultvalue(80)] int width, [in, defaultvalue(25)] int height, [out, retval] Window_FixedText** retval);
+      HRESULT NewWindow_Graphics([in] int width, [in] int height, [out, retval] Window_Graphics** retval);
+      HRESULT NewWindow_Text([in, defaultvalue(320)] int width, [in, defaultvalue(240)] int height, [out, retval] Window_Text** retval);
 
-      HRESULT NewWindow([out, retval] IWindow_Main** retval);
-      HRESULT SetOnNewWindow([in, defaultvalue(0)] IDispatch *pDisp, [in, defaultvalue(0)] VARIANT var);
+      HRESULT NewWindow([out, retval] Window_Main** retval);
+      HRESULT SetOnNewWindow([in, defaultvalue(0)] IDispatch *OnNewWindow, [in, defaultvalue(0)] VARIANT userdata);
 
-      HRESULT CreateInterval([in] int iTimeOut, [in] IDispatch *pDisp, [in, defaultvalue(0)] VARIANT var, [out, retval] ITimer **retval);
-      HRESULT CreateTimeout([in] int iTimeOut, [in] IDispatch *pDisp, [in, defaultvalue(0)] VARIANT var, [out, retval] ITimer **retval);
+      [helpcontext(2)]
+      HRESULT CreateInterval([in] int time_in_ms, [in] IDispatch *OnTimer, [in, defaultvalue(0)] VARIANT userdata, [out, retval] Timer **retval);
 
-      HRESULT New_Socket([out, retval] ISocket **retval);
-      HRESULT New_SocketServer([in] unsigned int iPort, 
-                               [in] IDispatch *pDisp, [in, defaultvalue(0)] VARIANT var,
-                               [out, retval] ISocketServer **retval);
+      [helpcontext(3)]
+      HRESULT CreateTimeout([in] int time_in_ms, [in] IDispatch *OnTimer, [in, defaultvalue(0)] VARIANT userdata, [out, retval] Timer **retval);
 
-      HRESULT ReverseDNSLookup([in] BSTR bstrIP, [in] IDispatch *pDisp, [in, defaultvalue(0)] VARIANT var);
-      // pDisp(bstr hostname, var);
-      // function Lookup(hostname) { window.output.write(hostname); } app.ReverseDNSLookup("127.0.0.1", Lookup);
+      HRESULT New_Socket([out, retval] Socket **retval);
+      HRESULT New_SocketServer([in] unsigned int port, 
+                               [in] IDispatch *OnConnection, [in, defaultvalue(0)] VARIANT userdata,
+                               [out, retval] SocketServer **retval);
 
-      HRESULT ForwardDNSLookup([in] BSTR bstrName, [in] IDispatch *pDisp, [in, defaultvalue(0)] VARIANT var);
-      // pDisp(bstr hostIP, var);
-      // function Lookup(hostip) { window.output.write(hostip); } app.ForwardDNSLookup("www.msn.com", Lookup);
+      [helpstring(
+         "Callback function signature: <font color='lime'>OnLookup</font>(string hostname, variant userdata)\n"
+         "\n"
+         "Example Usage:\n"
+         "function Lookup(hostname) { window.output.write(hostname); }\n"
+         "app.ReverseDNSLookup(\"127.0.0.1\", Lookup);")]
+      HRESULT ReverseDNSLookup([in] BSTR ip_address, [in] IDispatch *OnLookup, [in, defaultvalue(0)] VARIANT userdata);
 
-      HRESULT IsAddress([in] BSTR bstrIP, [out, retval] VARIANT_BOOL *pResult);
+      [helpstring(
+         "Callback function signature: OnLookup(string hostip, variant userdata)\n"
+         "\n"
+         "Example usage:\n"
+         "function Lookup(hostip) { window.output.write(hostip); }\n"
+         "app.ForwardDNSLookup(\"www.msn.com\", Lookup);")]
+      HRESULT ForwardDNSLookup([in] BSTR hostname, [in] IDispatch *OnLookup, [in, defaultvalue(0)] VARIANT userdata);
+
+      HRESULT IsAddress([in] BSTR ip_address, [out, retval] VARIANT_BOOL *pResult);
 
       HRESULT PlaySound([in] BSTR filename, [in, defaultvalue(1.0)] float volume);
       HRESULT StopSounds();
 
-      HRESULT OutputDebugHTML([in] BSTR bstr);
-      HRESULT OutputDebugText([in] BSTR bstr);
+      HRESULT OutputDebugHTML([in] BSTR html);
+      HRESULT OutputDebugText([in] BSTR text);
    }
 
    [ uuid(36A385C7-A258-4210-A61C-EB3890501903), oleautomation, dual, nonextensible ]
-   interface IBeip : IDispatch
+   interface Beip : IDispatch
    {
-      [propget] HRESULT Window([out, retval] IWindow_Main** retval);
-      [propget] HRESULT App([out, retval] IApp** retval);
+      [propget] HRESULT Window([out, retval] Window_Main** retval);
+      [propget] HRESULT App([out, retval] App** retval);
    }
 }

--- a/src/OM_Help.cpp
+++ b/src/OM_Help.cpp
@@ -5,6 +5,28 @@
 #include "Main.h"
 #include "OM_Help.h"
 
+static ConstString s_help[] =
+{
+// None
+"",
+// WebView::SetOnDisplayCapture
+R"(Register a callback to call for a range of lines about to be displayed. The regex determines when the range starts and ends.
+When the regex_begin matches, OnCaptureChanged will be called with 'starting=true', then for each line in the capture, OnCapture will be called. When a line matching regex_end occurs, OnCaptureChagned will be called with 'starting=false'
+
+Callback function signatures:
+  void OnCapture(int id, ITextWindowLine line)
+  void OnCaptureChanged(int id, ITextWindowLine line, bool starting))",
+// App::CreateInterval
+R"(Register a callback to be called repeatedly every time interval.
+Callback function signature: <font color='lime'>OnTimer</font>(variant userdata)
+
+Example Usage:
+function TimerCallback(ud) { ud.window.output.write('Timer called with userdata: ' + ud.text); }
+app.CreateTimeout(1000, TimerCallback, { window: window, text: 'Test Timeout'});)",
+// App::CreateTimeout
+"Register a callback to be called once after the time elapses. See 'CreateInterval' for the callback syntax and code sample'"
+};
+
 IServiceProvider *GetServiceProvider();
 
 namespace OM
@@ -52,17 +74,23 @@ void ClearHooks()
    }
 }
 
-HRESULT LoadTypeInfoFromThisModule(REFIID riid, ITypeInfo **ppti) 
+static CntPtrTo<ITypeLib> sp_type_lib;
+
+ITypeLib &GetTypeLib()
+{
+   if(!sp_type_lib)
+      LoadTypeLibEx(UTF16(ModuleFileName()).stringz(), REGKIND_NONE, sp_type_lib.Address());
+
+   Assert(sp_type_lib);
+   return *sp_type_lib;
+}
+
+void LoadTypeInfoFromThisModule(REFIID riid, ITypeInfo **ppti) 
 {
    *ppti = 0;
-
-   HRESULT hr = E_FAIL;
-   CntPtrTo<ITypeLib> ptl;
-   if(SUCCEEDED(LoadTypeLibEx(UTF16(ModuleFileName()).stringz(), REGKIND_NONE, ptl.Address())))
-      hr = ptl->GetTypeInfoOfGuid(riid, ppti);
-
+   HRESULT hr=GetTypeLib().GetTypeInfoOfGuid(riid, ppti);
    Assert(SUCCEEDED(hr));
-   return hr;
+   hr;
 }
 
 OwnedBSTR ReadFileAsBSTR(ConstString fileName)
@@ -107,6 +135,264 @@ HRESULT SystemTimeToVariant(VARIANT &var, const Time::Time &timeObject)
    var.vt=VT_DATE;
    var.date=date;
    return S_OK;
+}
+
+void TypeToString(ITypeInfo &ti, const TYPEDESC &td, StringBuilder &string)
+{
+   string("<font color='#00FFFF'>");
+   scope_success _([&] { string("</font>"); });
+
+   if(td.vt == VT_PTR && td.lptdesc)
+   {
+      TypeToString(ti, *td.lptdesc, string);
+      string('*');
+      return;
+   }
+
+   if(td.vt == VT_USERDEFINED)
+   {
+      CntPtrTo<ITypeInfo> pti;
+      if(FAILED(ti.GetRefTypeInfo(td.hreftype, pti.Address())) || !pti)
+      {
+         string("unknown");
+         return;
+      }
+      OwnedBSTR bstrName;
+      pti->GetDocumentation(MEMBERID_NIL, bstrName.Address(), nullptr, nullptr, nullptr);
+      BSTRToLStr name(bstrName);
+      string("<run text='/shelp ", name, "'>", name, "</run>");
+      return;
+   }
+
+   switch(td.vt)
+   {
+      case VT_I1: string("int8"); break;
+      case VT_I2: string("int16"); break;
+      case VT_I4: string("int32"); break;
+      case VT_R4: string("float32"); break;
+      case VT_R8: string("float64"); break;
+      case VT_DATE: string("date"); break;
+      case VT_BSTR: string("string"); break;
+      case VT_DISPATCH: string("callback"); break;
+      case VT_BOOL: string("bool"); break;
+      case VT_VARIANT: string("variant"); break;
+      case VT_UI1: string("uint8"); break;
+      case VT_UI2: string("uint16"); break;
+      case VT_UI4: string("uint32"); break;
+      case VT_INT: string("int"); break;
+      case VT_UINT: string("uint"); break;
+      case VT_VOID: string("void"); break;
+      case VT_PTR: string("pointer"); break;
+      default: string("{unknown ", td.vt, "}"); break;
+   }
+}
+
+void DisplayTypeInfo(ITypeInfo &ti, Text::Wnd &wnd)
+{
+   HybridStringBuilder string;
+
+   // Prepend type name and documentation
+   {
+      OwnedBSTR type_name, type_help;
+      DWORD help_context{};
+      // MEMBERID_NIL requests documentation for the type itself
+      ti.GetDocumentation(MEMBERID_NIL, type_name.Address(), type_help.Address(), &help_context, nullptr);
+
+      string("<p background-color='#004000' stroke-color='#008000' stroke-width='2' border='10' border-style='round' padding='2'>",
+         "<font size='20'>", BSTRToLStr(type_name), "</font>");
+
+      if(type_help)
+         string("\n", BSTRToLStr(type_help));
+      if(help_context)
+         string(BSTRToLStr(s_help[help_context]));
+
+      string("</p>");
+      wnd.Add(CreateLineInternal(string)); string.Clear();
+   }
+
+   TYPEATTR *p_ta{};
+   if(FAILED(ti.GetTypeAttr(&p_ta)) || !p_ta)
+      return;
+   scope_exit _{[&]() { ti.ReleaseTypeAttr(p_ta); }};
+
+   for(UINT i = 0; i < p_ta->cFuncs; i++)
+   {
+      FUNCDESC *p_fd{};
+      if(FAILED(ti.GetFuncDesc(i, &p_fd) || !p_fd))
+         continue;
+      scope_exit _{[&]() { ti.ReleaseFuncDesc(p_fd); }};
+
+      if(p_fd->wFuncFlags & FUNCFLAG_FHIDDEN)
+         continue; // string("[hidden] ");
+      if(p_fd->wFuncFlags & FUNCFLAG_FRESTRICTED)
+         continue; // string("[restricted] ");
+      if(p_fd->wFuncFlags & FUNCFLAG_FDEFAULTBIND)
+         string("[defaultbind] ");
+      if(p_fd->memid == DISPID_VALUE)
+         string("[default value] ");
+
+      // Get names: function name + parameter names
+      UINT nameCount = p_fd->cParams + 1;
+      OwnedArray<BSTR> names(nameCount);
+      for(auto &name : names)
+         name = nullptr;
+
+      UINT cGot = 0;
+      ti.GetNames(p_fd->memid, names.begin(), nameCount, &cGot);
+      scope_exit _{[&]() {
+         for(auto name : names)
+            if(name)
+               SysFreeString(name);
+      }};
+
+      if(cGot==0 || !names[0])
+         continue;
+
+      string("<font color='lime'>", names[0], "</font>");
+
+      switch(p_fd->invkind)
+      {
+         case INVOKE_FUNC:
+         {
+            string('(');
+            // Parameters
+            for(UINT i = 0; i < UINT(p_fd->cParams); ++i)
+            {
+               if(i)
+                  string(", ");
+
+               auto &param=p_fd->lprgelemdescParam[i];
+               auto &pd=param.paramdesc;
+               TypeToString(ti, param.tdesc, string);
+               if(i + 1 < cGot && names[i+1])
+                  string(' ', names[i+1]);
+
+               if(pd.wParamFlags & PARAMFLAG_FOPT)
+               {
+                  if((pd.wParamFlags & PARAMFLAG_FHASDEFAULT) && pd.pparamdescex)
+                  {
+                     string(" = ");
+                     const VARIANT &v = pd.pparamdescex->varDefaultValue;
+                     if(v.vt==VT_DISPATCH && v.pdispVal==nullptr)
+                     {
+                        string("null");
+                     }
+                     else if(v.vt==VT_BOOL)
+                     {
+                        if(v.boolVal!=0)
+                           string("true");
+                        else
+                           string("false");
+                     }
+                     else
+                     {
+                        Variant vstring;
+                        if(vstring.Convert<BSTR>(v))
+                           string(BSTRToLStr(vstring.bstrVal));
+                        else
+                           string("(unsupported default value)");
+                     }
+                  }
+               }
+            }
+
+            string(")");
+
+            // Return type
+            if(p_fd->elemdescFunc.tdesc.vt!=VT_VOID)
+            {
+               string(" -> ");
+               TypeToString(ti, p_fd->elemdescFunc.tdesc, string);
+            }
+            break;
+         }
+
+         case INVOKE_PROPERTYGET:
+         {
+            string(' ');
+            TypeToString(ti, p_fd->elemdescFunc.tdesc, string);
+            bool read_write=false;
+
+            // If next function is the INVOKE_PROPERTYPUT, then skip it and say [read/write]
+            if(i + 1 < p_ta->cFuncs)
+            {
+               FUNCDESC *p_fd_next{};
+               if(SUCCEEDED(ti.GetFuncDesc(i + 1, &p_fd_next)) && p_fd_next)
+               {
+                  scope_exit _{[&]() { ti.ReleaseFuncDesc(p_fd_next); }};
+                  if(p_fd_next->invkind == INVOKE_PROPERTYPUT && p_fd_next->memid == p_fd->memid)
+                  {
+                     read_write=true;
+                     ++i; // Skip the next one
+                  }
+               }
+            }
+
+            if(read_write)
+               string(" [read/write]");
+            else
+               string(" [read]");
+            break;
+         }
+
+         case INVOKE_PROPERTYPUT:
+            string(' ');
+            TypeToString(ti, p_fd->lprgelemdescParam[0].tdesc, string);
+            string(" [write]");
+            break;
+         case INVOKE_PROPERTYPUTREF:
+            string(' ');
+            TypeToString(ti, p_fd->lprgelemdescParam[0].tdesc, string);
+            string(" [writeref]");
+            break;
+      }
+
+      wnd.Add(CreateLineInternal(string));
+      string.Clear();
+
+      // Documentation string
+      OwnedBSTR bstrDoc, bstrHelpFile;
+      DWORD help_context{};
+      ti.GetDocumentation(p_fd->memid, nullptr, bstrDoc.Address(), &help_context, bstrHelpFile.Address());
+      if(bstrDoc || help_context)
+      {
+         string("<p indent='2' border='10' border-style='round'>", BSTRToLStr(bstrDoc));
+         string(s_help[help_context]);
+         wnd.Add(CreateLineInternal(string));
+         string.Clear();
+      }
+   }
+}
+
+void GetOMHelp(ConstString topic, Text::Wnd &wnd)
+{
+   auto &tl=GetTypeLib();
+
+   if(topic.ICompare("all")==0)
+   {
+      // Show all types in the type library
+      UINT type_count=tl.GetTypeInfoCount();
+      for(UINT i=0; i<type_count; i++)
+      {
+         CntPtrTo<ITypeInfo> p_type_info;
+         if(FAILED(tl.GetTypeInfo(i, p_type_info.Address())) || !p_type_info)
+            continue;
+
+         OwnedBSTR type_name;
+         p_type_info->GetDocumentation(MEMBERID_NIL, type_name.Address(), nullptr, nullptr, nullptr);
+         wnd.Add(CreateLineInternal(BSTRToLStr(type_name)));
+      }
+      return;
+   }
+
+   CntPtrTo<ITypeInfo> p_type_info;
+   MEMBERID member_ids[1];
+   USHORT ids_found=1;
+   tl.FindName(OwnedBSTR(topic), 0, p_type_info.Address(), member_ids, &ids_found);
+   if(p_type_info)
+      DisplayTypeInfo(*p_type_info, wnd);
+   else
+      wnd.AddHTML("Type not found");
 }
 
 };

--- a/src/OM_Help.h
+++ b/src/OM_Help.h
@@ -7,12 +7,12 @@ namespace OM
 {
 
 // Object Creation (where the internal header isn't needed)
-interface IWindow_Graphics;
+interface I::Window_Graphics;
 
-IWindow_Graphics  *Create_Window_Graphics(int2 sz);
-IWindow_FixedText *Create_Window_FixedText(int2 sz);
+I::Window_Graphics  *Create_Window_Graphics(int2 sz);
+I::Window_FixedText *Create_Window_FixedText(int2 sz);
 
-HRESULT LoadTypeInfoFromThisModule(REFIID riid, ITypeInfo **ppti);
+void LoadTypeInfoFromThisModule(REFIID riid, ITypeInfo **ppti);
 
 #define E_ZOMBIE E_POINTER
 
@@ -108,6 +108,8 @@ struct Variant : VARIANT
 
    bool operator==(bool f) const noexcept { return Is<VARIANT_BOOL>() && boolVal==BoolVariant(f); }
 };
+
+void GetOMHelp(ConstString topic, Text::Wnd &wnd);
 
 template<typename T>
 struct __declspec(novtable) Dispatch : General::Unknown<T>
@@ -276,11 +278,11 @@ template<typename TEvent, typename TBase, typename TSender>
 HRESULT ManageHook(TBase *pBase, HookVariant &hook, TSender &sender, IDispatch *pDisp, VARIANT &var)
 {
    if(hook)
-      pBase->Detach<TEvent>();
+      pBase->template Detach<TEvent>();
    hook.Set(pDisp, var);
 
    if(pDisp)
-      pBase->AttachTo<TEvent>(sender);
+      pBase->template AttachTo<TEvent>(sender);
    return S_OK;
 }
 

--- a/src/OM_Logging.cpp
+++ b/src/OM_Logging.cpp
@@ -24,7 +24,7 @@ HRESULT Log::Write(BSTR bstr)
    return S_OK;
 }
 
-HRESULT Log::WriteLine(ITextWindowLine *pLine)
+HRESULT Log::WriteLine(I::TextWindowLine *pLine)
 {
    ZOMBIECHECK
    mp_log->LogTextLine(static_cast<TextWindowLine *>(pLine)->GetInternal());

--- a/src/OM_Logging.h
+++ b/src/OM_Logging.h
@@ -7,7 +7,7 @@
 namespace OM
 {
 
-struct Log : Dispatch<ILog>
+struct Log : Dispatch<I::Log>
 {
    Log(::Log *pLog);
 
@@ -15,7 +15,7 @@ struct Log : Dispatch<ILog>
 
    // ILog
    STDMETHODIMP Write(BSTR bstr) override;
-   STDMETHODIMP WriteLine(ITextWindowLine *pLine) override;
+   STDMETHODIMP WriteLine(I::TextWindowLine *pLine) override;
    STDMETHODIMP get_FileName(BSTR *bstr) override;
 
    NotifiedPtrTo<::Log> mp_log;

--- a/src/OM_Props.idl
+++ b/src/OM_Props.idl
@@ -1,7 +1,7 @@
-interface ITriggers;
+interface Triggers;
 
 [ uuid(d51a0ef9-a9e1-445a-850d-7bd00f339aae), oleautomation, dual, nonextensible ]
-interface IFindString : IDispatch
+interface FindString : IDispatch
 {
    [propget] HRESULT MatchText([out, retval] BSTR *);
    [propput] HRESULT MatchText([in] BSTR);
@@ -22,11 +22,11 @@ interface IFindString : IDispatch
 }
 
 [ uuid(dc81a328-691f-4856-9169-927880201559), oleautomation, dual, nonextensible ]
-interface ITrigger : IDispatch
+interface Trigger : IDispatch
 {
    HRESULT Delete([out, retval] VARIANT_BOOL *); // Returns true if successful
 
-   [propget] HRESULT FindString([out, retval] IFindString **);
+   [propget] HRESULT FindString([out, retval] FindString **);
 
    [propget] HRESULT Disabled([out, retval] VARIANT_BOOL *);
    [propput] HRESULT Disabled([in] VARIANT_BOOL);
@@ -42,22 +42,25 @@ interface ITrigger : IDispatch
    [propget] HRESULT Away([out, retval] VARIANT_BOOL *);
    [propput] HRESULT Away([in] VARIANT_BOOL);
 
-   [propget] HRESULT Triggers([out, retval] ITriggers **);
+   [propget] HRESULT Triggers([out, retval] Triggers **);
 }
 
 [ uuid(5f02c414-aa5e-48b0-adda-1a73c57b1dd0), oleautomation, dual, nonextensible ]
-interface ITriggers : IDispatch
+interface Triggers : IDispatch
 {
-	[propget, id(DISPID_VALUE)] HRESULT Item([in] VARIANT var, [out, retval] ITrigger **);
+	[id(DISPID_VALUE)] HRESULT Item([in] VARIANT var, [out, retval] Trigger **);
 	[propget] HRESULT Count([out, retval] long *);
 
+   [propget] HRESULT Active([out, retval] VARIANT_BOOL *);
+   [propput] HRESULT Active([in] VARIANT_BOOL);
+
    HRESULT Delete([in] long index);
-   HRESULT AddCopy([in] ITrigger *, [out, retval] ITrigger **);
+   HRESULT AddCopy([in] Trigger *trigger, [out, retval] Trigger **);
 //   HRESULT Move([in] long from, [in] long to);
 }
 
 [ uuid(891F5181-E618-4EAD-B89F-A6B988129C02), oleautomation, dual, nonextensible ]
-interface IAlias : IDispatch
+interface Alias : IDispatch
 {
    [propget] HRESULT StopProcessing([out, retval] VARIANT_BOOL *);
    [propput] HRESULT StopProcessing([in] VARIANT_BOOL);
@@ -66,14 +69,14 @@ interface IAlias : IDispatch
 }
 
 [ uuid(D9BDF164-DFD3-433B-9CA8-CE312E08DF00), oleautomation, dual, nonextensible ]
-interface IAliases : IDispatch
+interface Aliases : IDispatch
 {
-   [propget, id(DISPID_VALUE)] HRESULT Item([in] VARIANT var, [out, retval] IAlias **);
+   [id(DISPID_VALUE)] HRESULT Item([in] VARIANT index, [out, retval] Alias **);
    [propget] HRESULT Count([out, retval] long *);
 }
 
 [ uuid(2f45ae30-3f0c-487a-be87-f79acf9b0608), oleautomation, dual, nonextensible ]
-interface IPuppet : IDispatch
+interface Puppet : IDispatch
 {
    [propget] HRESULT Name([out, retval] BSTR *);
    [propput] HRESULT Name([in] BSTR);
@@ -92,19 +95,19 @@ interface IPuppet : IDispatch
    [propget] HRESULT ConnectWithPlayer([out, retval] VARIANT_BOOL *);
    [propput] HRESULT ConnectWithPlayer([in] VARIANT_BOOL);
 
-   [propget] HRESULT Triggers([out, retval] ITriggers **);
-   [propget] HRESULT Aliases([out, retval] IAliases **);
+   [propget] HRESULT Triggers([out, retval] Triggers **);
+   [propget] HRESULT Aliases([out, retval] Aliases **);
 }
 
 [ uuid(432dfd7e-be27-469e-b848-b50452405dda), oleautomation, dual, nonextensible ]
-interface IPuppets : IDispatch
+interface Puppets : IDispatch
 {
-	[propget, id(DISPID_VALUE)] HRESULT Item([in] VARIANT var, [out, retval] IPuppet**);
+	[id(DISPID_VALUE)] HRESULT Item([in] VARIANT var, [out, retval] Puppet**);
 	[propget] HRESULT Count([out, retval] long *);
 }
 
 [ uuid(AFD5A7A1-D926-4a41-8BC3-923FAC7FECE7), oleautomation, dual, nonextensible ]
-interface ICharacter : IDispatch
+interface Character : IDispatch
 {
 	[propget] HRESULT Shortcut([out, retval] BSTR *);
 	[propput] HRESULT Shortcut([in] BSTR);
@@ -120,23 +123,23 @@ interface ICharacter : IDispatch
    [propget] HRESULT LastUsed([out, retval] VARIANT *date);
    [propget] HRESULT TimeCreated([out, retval] VARIANT *date);
 
-   [propget] HRESULT Triggers([out, retval] ITriggers **);
-   [propget] HRESULT Aliases([out, retval] IAliases **);
-   [propget] HRESULT Puppets([out, retval] IPuppets **);
+   [propget] HRESULT Triggers([out, retval] Triggers **);
+   [propget] HRESULT Aliases([out, retval] Aliases **);
+   [propget] HRESULT Puppets([out, retval] Puppets **);
 }
 
 [ uuid(645AFA5B-1D86-4eac-B062-C7F8A3AE00BD), oleautomation, dual, nonextensible ]
-interface ICharacters : IDispatch
+interface Characters : IDispatch
 {
 //		HRESULT New([out, retval] IWorld** retval);
 //		HRESULT Remove([in] IWorld *pWorld);
 
-	[propget, id(DISPID_VALUE)] HRESULT Item([in] VARIANT var, [out, retval] ICharacter **);
+	[id(DISPID_VALUE)] HRESULT Item([in] VARIANT var, [out, retval] Character **);
 	[propget] HRESULT Count([out, retval] long *);
 }
 
 [ uuid(A6AEFF4B-EBD9-4bb9-B118-F7C253B2D78A), oleautomation, dual, nonextensible ]
-interface IWorld : IDispatch
+interface World : IDispatch
 {
 	[propget] HRESULT Shortcut([out, retval] BSTR *);
 	[propput] HRESULT Shortcut([in] BSTR);
@@ -147,18 +150,18 @@ interface IWorld : IDispatch
 	[propget] HRESULT Host([out, retval] BSTR *);
 	[propput] HRESULT Host([in] BSTR);
 
-	[propget] HRESULT Characters([out, retval] ICharacters **);
-   [propget] HRESULT Triggers([out, retval] ITriggers **);
-   [propget] HRESULT Aliases([out, retval] IAliases **);
+	[propget] HRESULT Characters([out, retval] Characters **);
+   [propget] HRESULT Triggers([out, retval] Triggers **);
+   [propget] HRESULT Aliases([out, retval] Aliases **);
 }
 
 [ uuid(C79D75D4-6F7F-47b0-BD1A-EEA0FF8DE39F), oleautomation, dual, nonextensible ]
-interface IWorlds : IDispatch
+interface Worlds : IDispatch
 {
 //		HRESULT New([out, retval] IWorld** retval);
 //		HRESULT Remove([in] IWorld *pWorld);
 
-	[propget, id(DISPID_VALUE)] HRESULT Item([in] VARIANT var, [out, retval] IWorld**);
+	[id(DISPID_VALUE)] HRESULT Item([in] VARIANT index, [out, retval] World**);
 	[propget] HRESULT Count([out, retval] long *);
 }
 

--- a/src/OM_Sockets.h
+++ b/src/OM_Sockets.h
@@ -7,13 +7,13 @@ namespace OM
 {
 
 struct Socket
- : Dispatch<ISocket>,
+ : Dispatch<I::Socket>,
    Sockets::Socket::INotify,
    Sockets::GetHost::INotify
 {
    Socket(SOCKET socket=INVALID_SOCKET);
 
-   USE_INHERITED_UNKNOWN(ISocket)
+   USE_INHERITED_UNKNOWN(I::Socket)
 
    // IUnknown
    STDMETHODIMP QueryInterface(REFIID riid, void **ppvObj);
@@ -54,12 +54,12 @@ private:
 };
 
 struct SocketServer
- : Dispatch<ISocketServer>,
+ : Dispatch<I::SocketServer>,
    Sockets::Server::INotify
 {
    SocketServer(unsigned int iPort, IDispatch *pDisp, VARIANT &var);
 
-   USE_INHERITED_UNKNOWN(ISocketServer)
+   USE_INHERITED_UNKNOWN(I::SocketServer)
 
    // IUnknown
    STDMETHODIMP QueryInterface(REFIID riid, void **ppvObj) override;
@@ -74,7 +74,7 @@ private:
    HookVariant m_hookConnection;
 };
 
-struct ReverseDNS : Dispatch<IReverseDNS>, Sockets::GetHost::INotify, Sockets::GetName::INotify, DLNode<ReverseDNS>
+struct ReverseDNS : Dispatch<I::ReverseDNS>, Sockets::GetHost::INotify, Sockets::GetName::INotify, DLNode<ReverseDNS>
 {
    ReverseDNS(ReverseDNS *pInsertAfter, BSTR bstrIP, IDispatch *pDisp, VARIANT &var);
 
@@ -92,7 +92,7 @@ private:
    AsyncOwner<Sockets::GetName> m_pGetName;
 };
 
-struct ForwardDNS : Dispatch<IForwardDNS>, Sockets::GetHost::INotify, DLNode<ForwardDNS>
+struct ForwardDNS : Dispatch<I::ForwardDNS>, Sockets::GetHost::INotify, DLNode<ForwardDNS>
 {
    ForwardDNS(ForwardDNS *pInsertAfter, BSTR bstrName, IDispatch *pDisp, VARIANT &var);
 

--- a/src/OM_Window_Input.h
+++ b/src/OM_Window_Input.h
@@ -4,7 +4,7 @@ struct InputControl;
 namespace OM
 {
 
-struct Window_Input : Dispatch<IWindow_Input>
+struct Window_Input : Dispatch<I::Window_Input>
 {
    Window_Input(InputControl &input);
 

--- a/src/OM_Window_Properties.h
+++ b/src/OM_Window_Properties.h
@@ -5,7 +5,7 @@ namespace OM
 {
 
 struct Window_Properties
-:  Dispatch<OM::IWindow_Properties>,
+:  Dispatch<OM::I::Window_Properties>,
    Events::ReceiversOf<Window_Properties, Events::Event_Deleted>
 {
    Window_Properties(Window window, Events::SenderOf<Events::Event_Deleted> &deleted);

--- a/src/PropFuncs.cpp
+++ b/src/PropFuncs.cpp
@@ -88,15 +88,14 @@ bool Font::ChooseFont(HWND hWnd)
 //
 bool FindString::Find(ConstString string, unsigned start_index, uint2 &range) const
 {
-   FixedArray<uint2, 15> ranges;
-   auto result=Find(string, start_index, ranges);
+   auto result=Find(string, start_index);
    if(result.Count()==0)
       return false;
-   range=ranges[0];
+   range=result[0];
    return true;
 }
 
-Array<uint2> FindString::Find(ConstString string, unsigned start_index, Array<uint2> ranges) const
+Array<size_t_2> FindString::Find(ConstString string, unsigned start_index) const
 {
    if(fRegularExpression())
    {
@@ -104,14 +103,14 @@ Array<uint2> FindString::Find(ConstString string, unsigned start_index, Array<ui
          mp_regex_cache=MakeUnique<RegEx::Expression>(pclMatchText(), (fMatchCase() ? 0 : PCRE2_CASELESS)|PCRE2_UTF);
 
       if(fForward())
-         return mp_regex_cache->Find(string, start_index, ranges);
+         return mp_regex_cache->Find(string, start_index);
 
       // For a backwards search, look for the earliest search that ends before the start character
       // We do that by iterating forward, then backing up to the last valid match
       uint2 found;
       while(true)
       {
-         auto result=mp_regex_cache->Find(string, found.end, ranges);
+         auto result=mp_regex_cache->Find(string, found.end);
          if(!result)
             break;
 
@@ -126,14 +125,14 @@ Array<uint2> FindString::Find(ConstString string, unsigned start_index, Array<ui
       if(found.end==0)
          return {};
 
-      return mp_regex_cache->Find(string, found.begin, ranges);
+      return mp_regex_cache->Find(string, found.begin);
    }
 
    // Special case for an empty match, this will find 'nothing' at the start of the line
    if(!pclMatchText())
    {
-      ranges[0]={};
-      return ranges.First(1);
+      m_search_range={};
+      return {&m_search_range, 1};
    }
 
    unsigned found_index=Strings::Result::Not_Found;
@@ -199,8 +198,8 @@ Array<uint2> FindString::Find(ConstString string, unsigned start_index, Array<ui
    if(fWholeWord() && !IsWholeWord())
       return {};
 
-   ranges[0]=uint2(found_index, found_index+match_text.Length());
-   return ranges.First(1);
+   m_search_range={found_index, found_index+match_text.Length()};
+   return {&m_search_range, 1};
 }
 
 bool FindString::operator==(const FindString &pfs) const

--- a/src/RegEx.cpp
+++ b/src/RegEx.cpp
@@ -57,6 +57,7 @@ void Expression::GetError(StringBuilder &string) const
    string.AddLength(count-chars.Count()); // Add back unused space
 }
 
+#if 0
 std::optional<uint2> Expression::Find(ConstString string, unsigned start) const
 {
    int result_count=pcre2_match(m_code, (PCRE2_UCHAR8*)string.begin(), string.Length(), start, 0, m_data, nullptr);
@@ -69,20 +70,19 @@ std::optional<uint2> Expression::Find(ConstString string, unsigned start) const
 
    return uint2{unsigned(ovector[0]), unsigned(ovector[1])};
 }
+#endif
 
-Array<uint2> Expression::Find(ConstString string, unsigned start, Array<uint2> ranges) const
+Array<size_t_2> Expression::Find(ConstString string, unsigned start) const
 {
    int result_count=pcre2_match(m_code, (PCRE2_SPTR8)string.begin(), string.Length(), start, PCRE2_NO_UTF_CHECK, m_data, nullptr);
    if(result_count<=0)
       return {};
 
-   PinBelow(result_count, (int)ranges.Count());
+   auto *ovector=pcre2_get_ovector_pointer(m_data);
+   // static_assert that ovector is of type size_t
+   static_assert(std::is_same_v<decltype(ovector), size_t *>);
 
-   auto *ovector = pcre2_get_ovector_pointer(m_data);
-   for(int i=0;i<result_count;i++)
-      ranges[i]={unsigned(ovector[i*2]), unsigned(ovector[i*2+1])};
-
-   return ranges.First(result_count);
+   return {reinterpret_cast<size_t_2*>(pcre2_get_ovector_pointer(m_data)), static_cast<unsigned>(result_count)};
 }
 
 };

--- a/src/RegEx.h
+++ b/src/RegEx.h
@@ -13,8 +13,7 @@ struct Expression
    void GetError(StringBuilder &string) const;
    unsigned GetErrorOffset() const { return unsigned(m_error_offset); }
 
-   std::optional<uint2> Find(ConstString string, unsigned start) const;
-   Array<uint2> Find(ConstString string, unsigned start, Array<uint2> ranges) const;
+   Array<size_t_2> Find(ConstString string, unsigned start) const;
 
 private:
    Expression(const Expression&)=delete; // No way to copy the cached values

--- a/src/Root.prp
+++ b/src/Root.prp
@@ -106,8 +106,9 @@ Prop FindString
 
    Func "mutable CachedUniquePtr<RegEx::Expression> mp_regex_cache;"
    Func "bool Find(ConstString search, unsigned iStartChar, uint2 &found) const;"
-   Func "Array<uint2> Find(ConstString search, unsigned iStartChar, Array<uint2> ranges) const;"
+   Func "Array<size_t_2> Find(ConstString search, unsigned iStartChar) const;"
    Func "bool operator==(const FindString &pfs) const;"
+   Func "mutable size_t_2 m_search_range;" // For non regex searches
 }
 
 // Text window settings (duh)

--- a/src/Scripter.cpp
+++ b/src/Scripter.cpp
@@ -354,20 +354,20 @@ void DisplayScriptingEngines(Controls::ComboBox &list)
 // Beip
 //
 
-struct Beip : public Dispatch<IBeip>
+struct Beip : public Dispatch<I::Beip>
 {
-   Beip(IApp *p_app) : mp_app(p_app)
+   Beip(I::App *p_app) : mp_app(p_app)
    {
    }
 
-	STDMETHODIMP get_Window(IWindow_Main** retval) override { return ReturnRef(retval, mp_window); }
-	STDMETHODIMP get_App(IApp** retval) override { return ReturnRef(retval, mp_app); }
+	STDMETHODIMP get_Window(I::Window_Main** retval) override { return ReturnRef(retval, mp_window); }
+	STDMETHODIMP get_App(I::App** retval) override { return ReturnRef(retval, mp_app); }
 
-   void SetWindow(IWindow_Main *pWindow) { mp_window=pWindow; }
+   void SetWindow(I::Window_Main *pWindow) { mp_window=pWindow; }
 
 //private:
-   CntPtrTo<IApp> mp_app;
-   CntPtrTo<IWindow_Main> mp_window;
+   CntPtrTo<I::App> mp_app;
+   CntPtrTo<I::Window_Main> mp_window;
 };
 
 //

--- a/src/Telnet.cpp
+++ b/src/Telnet.cpp
@@ -347,7 +347,7 @@ void TelnetParser::Parse(Array<const char> buffer)
                {
                   FixedStringBuilder<256> reply(MakeString<TELNET_IAC, TELNET_SB, TELOPT_TTYPE, TELQUAL_IS>);
 
-                  // TTYPE sequence from here: https://github.com/nickgammon/mushclient/blob/201131914f643b24e65e2c846b8e12327225c598/telnet_phases.cpp#L761
+                  // TTYPE sequence from here: https://tintin.mudhalla.net/protocols/mtts/
                   switch(m_ttype_sequence++)
                   {
                      case 0:

--- a/src/TextToLine.cpp
+++ b/src/TextToLine.cpp
@@ -1,10 +1,11 @@
 ﻿#include "Main.h"
 #include "TextToLine.h"
 #include "CodePages.h"
+#include "ImageBanner.h"
 
 TextToLine::TextToLine(Wnd_Main &wndMain)
  : m_wnd_main(wndMain),
-   m_parserAnsi(g_ppropGlobal->propAnsi())
+   m_ansi_parser(g_ppropGlobal->propAnsi())
 {
 }
 
@@ -18,7 +19,7 @@ UniquePtr<Text::Line> TextToLine::Parse(ConstString string, bool use_pueblo, Pro
    Text::HTMLParser html(stream, m_line_builder);
 
    if(g_ppropGlobal->propAnsi().fResetOnNewLine())
-      m_parserAnsi.Reset();
+      m_ansi_parser.Reset();
    else
       m_line_builder.SetStyleState(m_prev_line_state);
 
@@ -28,7 +29,7 @@ UniquePtr<Text::Line> TextToLine::Parse(ConstString string, bool use_pueblo, Pro
       {
          case CHAR_ESC: // ESC
             if(stream.CharSpy()=='[')
-               m_parserAnsi.Parse(stream, m_line_builder);
+               m_ansi_parser.Parse(stream, m_line_builder);
             break;
 
          case CHAR_BEEP: // Beep
@@ -103,6 +104,60 @@ UniquePtr<Text::Line> TextToLine::Parse(ConstString string, bool use_pueblo, Pro
 
    m_prev_line_state=m_line_builder.GetStyleState();
    return m_line_builder.Create();
+}
+
+UniquePtr<Text::Line> CreateLineInternal(ConstString string)
+{
+   struct TagHandler : Text::ITagHandler
+   {
+      bool OnTag(Text::HTMLParser &html_parser, Text::LineBuilder &line_builder) override
+      {
+         auto &stream=html_parser.GetStream();
+         Streams::Input::PosRestorer restorer(stream);
+
+         bool start=!stream.CharSkip('/');
+
+         ConstString tag;
+         if(!html_parser.ParseName(tag))
+            return false;
+
+         // Parse tags in the form of <run text='cmd'> and turn them into Command_Send blocks
+         if(tag=="run")
+         {
+            if(start)
+            {
+               auto p_url=MakeCounting<Command_Send>();
+
+               Text::HTMLParser::Attribute attribute;
+               while(html_parser.ParseAttribute(attribute))
+               {
+                  if(attribute.m_name=="text")
+                  {
+                     p_url->m_command=attribute.m_value;
+                  }
+               }
+
+               line_builder.SetURL(MakeUnique<Text::Records::URLData>(*p_url));
+               line_builder.Set(Text::Records::Underline{true});
+            }
+            else
+            {
+               line_builder.Set(Text::Records::Underline{false});
+               line_builder.SetURL(nullptr);
+            }
+         }
+         else
+            return false;
+
+         if(stream.CharGet()!='>')
+            return false;
+
+         restorer.NoRestore();
+         return true;
+      }
+   } handler;
+
+   return Text::Line::Create(string, true, &handler);
 }
 
 void *Pueblo_Send::QueryInterface(TypeID id)
@@ -185,13 +240,18 @@ ConstString Pueblo_Send::OnRButton(Window wnd, int2 position) const
    return {};
 }
 
+void *Command_Send::QueryInterface(TypeID id)
+{
+   if(id==GetTypeID<Command_Send>())
+      return this;
+   return nullptr;
+}
+
 bool TextToLine::HandlePuebloTag(Streams::Input &stream, Text::HTMLParser &html)
 {
    Streams::Input::PosRestorer restorer(stream);
 
-   bool start=true;
-   if(stream.CharSkip('/'))
-      start=false;
+   bool start=!stream.CharSkip('/');
 
    ConstString tag;
    if(!html.ParseName(tag))
@@ -250,14 +310,14 @@ bool TextToLine::HandlePuebloTag(Streams::Input &stream, Text::HTMLParser &html)
          Text::HTMLParser::Attribute attribute;
          while(html.ParseAttribute(attribute))
          {
-            if(IEquals(attribute.m_name, "xch_mode"))
+            if(IEquals(attribute.m_name, "src"))
+            {
+               m_line_builder.AppendEmoji("🖼️");
+               m_line_builder.AppendURL(MakeUnique<Text::Records::URLData>(Text::Records::URLType::HTTP, attribute.m_value));
+            }
+            else if(IEquals(attribute.m_name, "height"))
             {
             }
-            else if(IEquals(attribute.m_name, "xch_graph"))
-            {
-            }
-            else
-               return false;
          }
       }
    }

--- a/src/WebView.cpp
+++ b/src/WebView.cpp
@@ -41,7 +41,7 @@ struct WebView2EnvironmentCreator : General::Unknown<ICoreWebView2CreateCoreWebV
 };
 
 struct WebView_OM
- : OM::Dispatch<OM::IWebView>,
+ : OM::Dispatch<OM::I::WebView>,
 	Events::ReceiversOf<WebView_OM, ::Connection::Event_Connect, ::Connection::Event_Disconnect, ::Connection::Event_Receive, ::Connection::Event_Display,
 	::Connection::Event_Send, ::Connection::Event_GMCP>
 {
@@ -245,6 +245,11 @@ struct WebView_OM
 				*out=nullptr;
 			return S_OK;
 		}
+		else if(property=="ID")
+		{
+			*out=LStrToBSTR(mp_wnd_webview->GetID());
+			return S_OK;
+		}
 		return S_FALSE;
 	}
 
@@ -261,10 +266,8 @@ struct WebView_OM
 
 		if(m_displays)
 		{
-			FixedArray<uint2, 15> ranges;
-
 			for(auto &p_display : m_displays)
-				if(p_display->mp_regex->Find(event.GetTextLine().GetText(), 0, ranges))
+				if(p_display->mp_regex->Find(event.GetTextLine().GetText(), 0))
 				{
 					CntPtrTo<IDispatch> p_line=new OM::TextWindowLine(event.GetTextLine());
 					p_display->m_hook(&*p_line, p_display->m_id);
@@ -279,12 +282,10 @@ struct WebView_OM
 		if(!m_captures)
 			return false;
 
-		FixedArray<uint2, 15> ranges;
-
 		if(!mp_capturing)
 		{
 			for(auto &p_capture : m_captures)
-				if(p_capture->mp_regex_begin->Find(event.GetTextLine().GetText(), 0, ranges))
+				if(p_capture->mp_regex_begin->Find(event.GetTextLine().GetText(), 0))
 				{
 					mp_capturing=p_capture;
 					break;
@@ -301,7 +302,7 @@ struct WebView_OM
 
 		CntPtrTo<IDispatch> p_line=new OM::TextWindowLine(event.GetTextLine());
 
-		if(mp_capturing->mp_regex_end->Find(event.GetTextLine().GetText(), 0, ranges))
+		if(mp_capturing->mp_regex_end->Find(event.GetTextLine().GetText(), 0))
 		{
 			mp_capturing->m_hook_capture_changed(false, &*p_line, mp_capturing->m_id);
 			event.Stop(mp_capturing->m_gag);
@@ -407,10 +408,10 @@ ATOM Wnd_WebView::Register()
 	return wc.Register();
 }
 
-Wnd_WebView::Wnd_WebView(Wnd_Main &wnd_main, ConstString id)
+Wnd_WebView::Wnd_WebView(Wnd_Main &wnd_main, int2 size, ConstString id)
 	: DLNode<Wnd_WebView>{wnd_main.GetWebViewRoot()}, m_wnd_main{wnd_main}, m_id{id}
 {
-	Create("WebView", WS_OVERLAPPEDWINDOW, Window::Position(int2(CW_USEDEFAULT, CW_USEDEFAULT), int2(800, 800)), wnd_main, WS_EX_APPWINDOW);
+	Create("WebView", WS_OVERLAPPEDWINDOW, Window::Position(int2(CW_USEDEFAULT, CW_USEDEFAULT), size), wnd_main, WS_EX_APPWINDOW);
 	mp_docking=&m_wnd_main.CreateDocking(*this);
 	Show(SW_SHOWNOACTIVATE);
 

--- a/src/WebView.h
+++ b/src/WebView.h
@@ -17,7 +17,7 @@ struct Wnd_WebView
 	};
 
 	static ATOM Register();
-	Wnd_WebView(Wnd_Main &wnd_main, ConstString id={});
+	Wnd_WebView(Wnd_Main &wnd_main, int2 size={800, 800}, ConstString id={});
 
 	ConstString GetURL() const { return m_url; }
 	void SetURL(ConstString url, Array<Header> headers={});

--- a/src/Window_Events_OM.h
+++ b/src/Window_Events_OM.h
@@ -2,7 +2,7 @@ namespace OM
 {
 
 struct Window_Events
-:  Dispatch<OM::IWindow_Events>,
+:  Dispatch<OM::I::Window_Events>,
    Events::ReceiversOf<Window_Events, Windows::Event_MouseMove, Windows::Event_Close, Windows::Event_Key>
 {
    Window_Events(WindowEvents *pEvents);

--- a/src/Wnd_FixedText_OM.cpp
+++ b/src/Wnd_FixedText_OM.cpp
@@ -32,12 +32,12 @@ void Window_FixedText::On(const Events::Event_Deleted &event)
    m_pEvents=nullptr; m_pProperties=nullptr; m_pWnd.Extract();
 }
 
-HRESULT Window_FixedText::get_Events(IWindow_Events **retval)
+HRESULT Window_FixedText::get_Events(I::Window_Events **retval)
 {
    return RefReturner(retval)(m_pEvents);
 }
 
-HRESULT Window_FixedText::get_Properties(IWindow_Properties **retval)
+HRESULT Window_FixedText::get_Properties(I::Window_Properties **retval)
 {
    return RefReturner(retval)(m_pProperties);
 }
@@ -84,7 +84,7 @@ HRESULT Window_FixedText::Write(BSTR bstr)
    return S_OK;
 }
 
-IWindow_FixedText *Create_Window_FixedText(int2 sz)
+I::Window_FixedText *Create_Window_FixedText(int2 sz)
 {
    return new Window_FixedText(sz);
 }

--- a/src/Wnd_FixedText_OM.h
+++ b/src/Wnd_FixedText_OM.h
@@ -4,14 +4,14 @@ namespace OM
 {
 
 struct Window_FixedText
-:  public Dispatch<IWindow_FixedText>,
+:  public Dispatch<I::Window_FixedText>,
    public Events::ReceiversOf<Window_FixedText, Events::Event_Deleted>
 {
    Window_FixedText(int2 size);
    ~Window_FixedText() noexcept;
 
-   STDMETHODIMP get_Events(IWindow_Events **retval);
-   STDMETHODIMP get_Properties(IWindow_Properties **retval);
+   STDMETHODIMP get_Events(I::Window_Events **retval);
+   STDMETHODIMP get_Properties(I::Window_Properties **retval);
 
    STDMETHODIMP put_CursorX(int x);
    STDMETHODIMP get_CursorX(int *pX);

--- a/src/Wnd_Main.cpp
+++ b/src/Wnd_Main.cpp
@@ -339,6 +339,7 @@ SpawnWindow *Wnd_Main::GetSpawnWindow(const Prop::Trigger_Spawn &trigger, ConstS
 
          p_tab_window=new SpawnTabsWindow(m_spawn_tabs_windows.Prev(), *this, replacement);
          p_tab_window->GetDocking().Dock(Docking::Side::Right);
+         SetDockedTitlePrefix(p_tab_window->GetDocking());
       }
 
       return p_tab_window->GetTab(title, nullptr, hilight, use_existing);
@@ -355,7 +356,10 @@ SpawnWindow *Wnd_Main::GetSpawnWindow(const Prop::Trigger_Spawn &trigger, ConstS
 
    auto &spawn=*new SpawnWindow(m_spawn_windows.Prev(), *this, title, *CopyIfNotGlobal(*mp_prop_output));
    if(spawn)
+   {
       spawn.GetDocking().Dock(Docking::Side::Right);
+      SetDockedTitlePrefix(spawn.GetDocking());
+   }
    return &spawn;
 }
 
@@ -365,6 +369,7 @@ Wnd_Image &Wnd_Main::EnsureImageWindow()
    {
       mp_wnd_image=CreateImageWindow(*this);
       mp_wnd_image->GetDocking().Dock(Docking::Side::Top);
+      SetDockedTitlePrefix(mp_wnd_image->GetDocking());
    }
 
    return *mp_wnd_image;
@@ -376,6 +381,7 @@ Maps::Wnd &Wnd_Main::EnsureMapWindow()
    {
       mp_wnd_map=MakeUnique<Maps::Wnd>(*this);
       mp_wnd_map->GetDocking().Dock(Docking::Side::Right);
+      SetDockedTitlePrefix(mp_wnd_map->GetDocking());
    }
    return *mp_wnd_map;
 }
@@ -393,6 +399,7 @@ AIWindow &Wnd_Main::EnsureAIWindow()
    {
       mp_ai_window=MakeUnique<AIWindow>(*this);
       mp_ai_window->GetDocking().Dock(Docking::Side::Bottom);
+      SetDockedTitlePrefix(mp_ai_window->GetDocking());
    }
    return *mp_ai_window;
 }
@@ -405,6 +412,7 @@ IYarn_TileMap &Wnd_Main::EnsureYarn_TileMap()
    {
       mp_yarn_tilemap=IYarn_TileMap::Create(*this);
       mp_yarn_tilemap->GetDocking().Dock(Docking::Side::Left);
+      SetDockedTitlePrefix(mp_yarn_tilemap->GetDocking());
    }
 #endif
 
@@ -431,6 +439,7 @@ Stats::Wnd &Wnd_Main::GetStatsWindow(ConstString title, bool fDock)
 
    auto *pStat=new Stats::Wnd(*this, title);
    pStat->DLNode<Stats::Wnd>::Link(m_stat_windows.Prev());
+   SetDockedTitlePrefix(pStat->GetDocking());
    if(fDock)
       pStat->GetDocking().Dock(Docking::Side::Right);
 
@@ -638,6 +647,7 @@ Wnd_InputPane* Wnd_Main::AddInputWindow(ConstString prefix, bool unique)
    p_props->pclPrefix(prefix);
    auto *p_input=CreateInputWindow(*p_props);
    p_input->GetDocking().Dock(Docking::Side::Bottom);
+   SetDockedTitlePrefix(p_input->GetDocking());
    return p_input;
 }
 
@@ -710,6 +720,7 @@ void Wnd_Main::ShowCharacterNotesPane()
 
       mp_character_notes_pane=MakeUnique<Wnd_EditPropertyPane>(*this, *pCharacter);
       mp_character_notes_pane->GetDocking().Dock(Docking::Side::Right);
+      SetDockedTitlePrefix(mp_character_notes_pane->GetDocking());
    }
    else
       MessageBox(*this, "You must connect with a character first", "Note", MB_OK|MB_ICONINFORMATION);
@@ -887,15 +898,19 @@ bool Wnd_Main::On(Text::Wnd &wnd_text, Text::Wnd_View &wnd_view, const Text::Rec
             return true;
 
          case Text::Records::URLType::Custom:
-            if(url.m_pCustom)
+            if(url.mp_custom)
             {
-               if(auto *pPueblo=url.m_pCustom->QueryInterface<Pueblo_Send>())
+               if(auto *p_pueblo=url.mp_custom->QueryInterface<Pueblo_Send>())
                {
-                  if(auto send=pPueblo->OnLButton())
+                  if(auto send=p_pueblo->OnLButton())
                   {
                      History_AddToHistory(send, ConstString());
                      mp_connection->Send(send);
                   }
+               }
+               else if(auto *p_command=url.mp_custom->QueryInterface<Command_Send>())
+               {
+                  SendLines(p_command->m_command);
                }
             }
             else
@@ -908,9 +923,9 @@ bool Wnd_Main::On(Text::Wnd &wnd_text, Text::Wnd_View &wnd_view, const Text::Rec
    }
    else if(_msg.uMessage()==Msg::RButtonDown::ID)
    {
-      if(url.m_pCustom)
+      if(url.mp_custom)
       {
-         if(auto *pPueblo=url.m_pCustom->QueryInterface<Pueblo_Send>())
+         if(auto *pPueblo=url.mp_custom->QueryInterface<Pueblo_Send>())
          {
             auto &msg=_msg.Cast<Msg::RButtonDown>();
             if(auto send=pPueblo->OnRButton(wnd_view, msg.position()))
@@ -966,6 +981,7 @@ bool Wnd_Main::On(Text::Wnd &wnd_text, Text::Wnd_View &wnd_view, const Text::Rec
             auto &wnd=*new Wnd_WebView(*this);
             wnd.SetURL(url.m_url);
             wnd.GetDocking().Dock(Docking::Side::Right);
+            SetDockedTitlePrefix(wnd.GetDocking());
             break;
          }
          case Commands::Copy: ::Clipboard::SetText(url.m_url); break;
@@ -1393,7 +1409,7 @@ Wnd_Docking *Wnd_Main::RestoreDockedWindowSettings(Prop::DockedWindow &propWindo
       case 9: // WebView
       {
          auto &props=propWindow.propWebViewWindow();
-         auto &wnd=*new Wnd_WebView(*this, props.pclID());
+         auto &wnd=*new Wnd_WebView(*this, {800, 800} /* Arbitrary starting size, will be overridden later by common code */, props.pclID());
          wnd.SetURL(props.pclURL());
          return &wnd.GetDocking();
       }
@@ -1409,6 +1425,15 @@ Wnd_Docking *Wnd_Main::RestoreDockedWindowSettings(Prop::DockedWindow &propWindo
 
    Assert(false);
    return nullptr;
+}
+
+void Wnd_Main::SetDockedTitlePrefix(Wnd_Docking &wnd)
+{
+   FixedStringBuilder<256> string;
+   mp_connection->GetWorldTitle(string, 0);
+   string(" - ");
+
+   wnd.SetUndockedTitlePrefix(string);
 }
 
 void Wnd_Main::Save()
@@ -1544,6 +1569,23 @@ void Wnd_Main::RestoreDockingConfiguration(Prop::Docking &propDocking)
          p_wnd->EnsureOnScreen();
          p_wnd->Show(SW_SHOWNOACTIVATE);
       }
+   }
+
+   // Update the titles of all windows
+   {
+      FixedStringBuilder<256> string;
+      mp_connection->GetWorldTitle(string, 0);
+      string(" - ");
+
+      // Iterate through all docked windows to notify them of the change
+      for(auto &frame : GetFrames())
+      {
+         for(auto &window : frame.GetWindows())
+            window.SetUndockedTitlePrefix(string);
+      }
+
+      for(auto &window : GetFloating())
+         window.SetUndockedTitlePrefix(string);
    }
    DockingChange();
 }
@@ -2059,6 +2101,10 @@ LRESULT Wnd_Main::On(const Msg::Command &msg)
          return msg.Success();
       }
 
+      case ID_HELP_SCRIPT:
+         ParseCommand("/shelp");
+         return msg.Success();
+
       case ID_HELP_CHANGES:
       {
          File::Path path{GetResourcePath(), "Changes.txt"};
@@ -2262,7 +2308,7 @@ bool Wnd_Main::ProcessEditKey(InputControl &edInput, const Msg::Key &msg)
 //
 // Returns true if Key should be processed by the Edit Control
 {
-   bool fDown=msg.direction()==Direction::Down;
+   bool is_down=msg.direction()==Direction::Down;
 
    KEY_ID key;
    key.iVKey=msg.iVirtKey();
@@ -2271,8 +2317,8 @@ bool Wnd_Main::ProcessEditKey(InputControl &edInput, const Msg::Key &msg)
    key.fAlt=IsKeyPressed(VK_MENU);
 
    // Refresh the taskbar when Alt is pressed/released to show the tab numbers
-   if(key.iVKey==VK_MENU && !(fDown && msg.fRepeating()))
-      mp_wnd_MDI->GetTaskbar().DrawTabNumbers(fDown);
+   if(key.iVKey==VK_MENU && !(is_down && msg.fRepeating()))
+      mp_wnd_MDI->GetTaskbar().DrawTabNumbers(is_down);
 
    // Ignore these keys as we don't do anything on them
    if(key.iVKey==VK_CONTROL || key.iVKey==VK_SHIFT || key.iVKey==VK_MENU)
@@ -2283,7 +2329,7 @@ bool Wnd_Main::ProcessEditKey(InputControl &edInput, const Msg::Key &msg)
       return false;
 
    // Don't process macros when the key is A-Z and no control or alt keys are pressed
-   if(fDown && (key.fControl || key.fAlt || !IsBetween<int>(key.iVKey, 'A', 'Z')) &&
+   if(is_down && (key.fControl || key.fAlt || !IsBetween<int>(key.iVKey, 'A', 'Z')) &&
        g_ppropGlobal->propConnections().propKeyboardMacros2().fActive())
    {
       const Prop::KeyboardMacro *p_macro=mp_connection->MacroKey(&key);
@@ -2306,7 +2352,7 @@ bool Wnd_Main::ProcessEditKey(InputControl &edInput, const Msg::Key &msg)
    }
 
    // Handle Alt+# tab switching
-   if(fDown && key.fAlt && !key.fControl && IsBetween<int>(key.iVKey, '0', '9'))
+   if(is_down && key.fAlt && !key.fControl && IsBetween<int>(key.iVKey, '0', '9'))
    {
       unsigned index=key.iVKey=='0' ? 10 : key.iVKey-'0';
       if(key.fShift)
@@ -2320,7 +2366,7 @@ bool Wnd_Main::ProcessEditKey(InputControl &edInput, const Msg::Key &msg)
    }
 
    // Send off a key event in case someone is listening
-   if(fDown)
+   if(is_down)
    {
       Event_Key event(key.iVKey);
       if(m_events.Send(event, event)) // If handler process key it'll return true, so we return false (meaning processed)
@@ -2347,7 +2393,7 @@ bool Wnd_Main::ProcessEditKey(InputControl &edInput, const Msg::Key &msg)
       return true;
    }
 
-   if(fDown) // Only handle the key on the down press
+   if(is_down) // Only handle the key on the down press
       HandleKey(edInput, eKey);
 
    return false;
@@ -2660,7 +2706,6 @@ void Wnd_Main::UpdateTitle()
 {
    FixedStringBuilder<256> sBuffer(m_title_prefix, m_title);
    __super::WndProc(Msg::SetText(UTF16(sBuffer).stringz()));
-
    GetMDI().OnWindowChanged(*this);
 }
 
@@ -3035,6 +3080,7 @@ void Wnd_MDI::PopupMainMenu(int2 position)
    {
       PopupMenu m;
       m.Append(MF_STRING, ID_HELP_CONTENTS, "&Contents...");
+      m.Append(MF_STRING, ID_HELP_SCRIPT, "&Scripting...");
    	m.Append(MF_STRING, ID_HELP_CHANGES, "Changes...");
       m.AppendSeparator();
       m.Append(MF_STRING, ID_HELP_ABOUT, "&About...");

--- a/src/Wnd_Main.h
+++ b/src/Wnd_Main.h
@@ -40,6 +40,7 @@ enum CommandIDs : int
    ID_EDIT_FINDINPUTHISTORY,
    ID_HELP_ABOUT,
    ID_HELP_CONTENTS,
+   ID_HELP_SCRIPT,
    ID_HELP_CHANGES,
    ID_NETWORK_DEBUGGER,
    ID_TRIGGER_DEBUGGER,
@@ -216,6 +217,7 @@ struct Wnd_Main
    void RestoreDockingConfiguration(Prop::Docking &propDocking);
 
    Wnd_Docking *RestoreDockedWindowSettings(Prop::DockedWindow &propWindow);
+   void SetDockedTitlePrefix(Wnd_Docking &wnd);
 
    void SaveMainWindowSettings(Prop::MainWindowSettings &settings);
    void ApplyMainWindowSettings();
@@ -489,11 +491,15 @@ private:
 
    struct DelayTimer : Time::Timer, DLNode<DelayTimer>
    {
-      DelayTimer(Wnd_Main &wnd_main, ConstString string, float seconds, bool repeating=false)
-       : Time::Timer([this]() { OnHit(); }),
-         DLNode<DelayTimer>(wnd_main.m_delay_timers.Prev()), m_wnd_main(wnd_main), m_string(string)
+      DelayTimer(Wnd_Main &wnd_main, ConstString string, float seconds, ConstString id={}, bool repeating=false)
+       : Time::Timer{[this]() { OnHit(); }},
+         DLNode<DelayTimer>{wnd_main.m_delay_timers.Prev()},
+         m_wnd_main{wnd_main}, m_string{string},
+         m_id{id}
       {
          Set(seconds, repeating);
+         if(!m_id)
+            m_id=Strings::to_string(wnd_main.m_next_delay_id++);
       }
 
       void OnHit()
@@ -505,7 +511,7 @@ private:
 
       Wnd_Main &m_wnd_main;
       OwnedString m_string;
-      unsigned m_id{m_wnd_main.m_next_delay_id++};
+      OwnedString m_id;
    };
 
    OwnedDLNodeList<DelayTimer> m_delay_timers;

--- a/src/Wnd_Main_OM.cpp
+++ b/src/Wnd_Main_OM.cpp
@@ -22,10 +22,10 @@ Docking::Docking(Wnd_Docking *pWnd)
 {
 }
 
-HRESULT Docking::Dock(Side side)
+HRESULT Docking::Dock(I::Side side)
 {
    ZOMBIECHECK
-   if(side<0 || side>Side_Bottom)
+   if(side<0 || side>I::Side_Bottom)
       return E_INVALIDARG;
 
    m_pWnd->Dock((::Docking::Side)side);
@@ -129,6 +129,20 @@ HRESULT MainWindow::get_Title(BSTR *retval)
    return S_OK;
 }
 
+HRESULT MainWindow::Activity()
+{
+   ZOMBIECHECK
+   mp_wnd_main->On(::Connection::Event_Activity{});
+   return S_OK;
+}
+
+HRESULT MainWindow::AddImportantActivity()
+{
+   ZOMBIECHECK
+   mp_wnd_main->AddImportantActivity();
+   return S_OK;
+}
+
 HRESULT MainWindow::GetVariable(BSTR name, BSTR *retval)
 {
    ZOMBIECHECK
@@ -165,7 +179,7 @@ HRESULT MainWindow::DeleteVariable(BSTR name)
    return S_OK;
 }
 
-HRESULT MainWindow::GetInput(BSTR title, IWindow_Input **retval)
+HRESULT MainWindow::GetInput(BSTR title, I::Window_Input **retval)
 {
    ZOMBIECHECK
    auto p_input=mp_wnd_main->FindInputWindow(BSTRToLStr(title));
@@ -178,7 +192,7 @@ HRESULT MainWindow::GetInput(BSTR title, IWindow_Input **retval)
    return S_OK;
 }
 
-HRESULT MainWindow::GetSpawnTabs(BSTR title16, IWindow_SpawnTabs **retval)
+HRESULT MainWindow::GetSpawnTabs(BSTR title16, I::Window_SpawnTabs **retval)
 {
    ZOMBIECHECK
    auto title=BSTRToLStr(title16);
@@ -256,7 +270,7 @@ void MainWindow::On(Wnd_Main::Event_Key &event)
 {
 }
 
-STDMETHODIMP Windows::get_Item(VARIANT var, IWindow_Main **retval)
+STDMETHODIMP Windows::get_Item(VARIANT var, I::Window_Main **retval)
 {
    Variant v2;
    if(v2.Convert<int32>(var))

--- a/src/Wnd_Main_OM.h
+++ b/src/Wnd_Main_OM.h
@@ -6,12 +6,12 @@ namespace OM
 interface ITextWindow;
 interface IConnection;
 
-struct Docking : Dispatch<IDocking>
+struct Docking : Dispatch<I::Docking>
 {
    Docking(Wnd_Docking *pWnd);
 
    // IDocking
-   STDMETHODIMP Dock(Side side); // Docks the window to a particular side
+   STDMETHODIMP Dock(I::Side side); // Docks the window to a particular side
 
 private:
    NotifiedPtrTo<Wnd_Docking> m_pWnd;
@@ -19,7 +19,7 @@ private:
 
 struct SpawnTabs
  : DLNode<SpawnTabs>,
-   Dispatch<IWindow_SpawnTabs>,
+   Dispatch<I::Window_SpawnTabs>,
    Events::ReceiversOf<SpawnTabs, SpawnTabsWindow::Event_Activate, Events::Event_Deleted>
 {
    SpawnTabs(MainWindow &main_window, SpawnTabsWindow &window);
@@ -36,45 +36,45 @@ private:
 };
 
 struct MainWindow
- : Dispatch<IWindow_Main>,
+ : Dispatch<I::Window_Main>,
    Events::ReceiversOf<MainWindow, Wnd_Main::Event_Command, Wnd_Main::Event_Activate, Wnd_Main::Event_Close, Wnd_Main::Event_Key>
 {
    MainWindow(Wnd_Main *pWnd_Main);
    ~MainWindow() noexcept;
    void Destroyed() { mp_wnd_main=nullptr; }
 
-   USE_INHERITED_UNKNOWN(IWindow_Main)
+   USE_INHERITED_UNKNOWN(I::Window_Main)
 
    // IUnknown
    STDMETHODIMP QueryInterface(REFIID riid, void **ppvObj) override;
 
    // IWindow methods
-   STDMETHODIMP get_Output(IWindow_Text **retval) override
+   STDMETHODIMP get_Output(I::Window_Text **retval) override
    {
       mp_text_window_output->AddRef(); *retval=mp_text_window_output;
       return S_OK;
    }
 
-   STDMETHODIMP get_History(IWindow_Text **retval) override
+   STDMETHODIMP get_History(I::Window_Text **retval) override
    {
       mp_text_window_history->AddRef(); *retval=mp_text_window_history;
       return S_OK;
    }
 
-   STDMETHODIMP get_Connection(IConnection **retval) override
+   STDMETHODIMP get_Connection(I::Connection **retval) override
    {
       mp_connection->AddRef(); *retval=mp_connection;
       return S_OK;
    }
 
-   STDMETHODIMP get_Input(IWindow_Input **retval) override
+   STDMETHODIMP get_Input(I::Window_Input **retval) override
    {
       mp_input->AddRef(); *retval=mp_input;
       return S_OK;
    }
 
-   STDMETHODIMP GetInput(BSTR title, IWindow_Input **retval);
-   STDMETHODIMP GetSpawnTabs(BSTR title, IWindow_SpawnTabs **retval);
+   STDMETHODIMP GetInput(BSTR title, I::Window_Input **retval);
+   STDMETHODIMP GetSpawnTabs(BSTR title, I::Window_SpawnTabs **retval);
 
    STDMETHODIMP get_UserData(VARIANT *pVar) override { VariantCopy(pVar, &m_varUserData); return S_OK; }
    void STDMETHODCALLTYPE put_UserData(VARIANT var) override { m_varUserData=var; }
@@ -94,6 +94,9 @@ struct MainWindow
    STDMETHODIMP get_TitlePrefix(BSTR *retval) override;
    STDMETHODIMP get_Title(BSTR *retval) override;
 
+   STDMETHODIMP Activity() override;
+   STDMETHODIMP AddImportantActivity() override;
+
    STDMETHODIMP GetVariable(BSTR name, BSTR *value) override;
    STDMETHODIMP SetVariable(BSTR name, BSTR value) override;
    STDMETHODIMP DeleteVariable(BSTR name) override;
@@ -106,10 +109,10 @@ struct MainWindow
    void On(Events::Event_Deleted &event, SpawnTabs &tab);
 
 private:
-   CntPtrTo<IWindow_Text> mp_text_window_output;
-   CntPtrTo<IWindow_Text> mp_text_window_history;
-   CntPtrTo<IConnection> mp_connection;
-   CntPtrTo<IWindow_Input> mp_input;
+   CntPtrTo<I::Window_Text> mp_text_window_output;
+   CntPtrTo<I::Window_Text> mp_text_window_history;
+   CntPtrTo<I::Connection> mp_connection;
+   CntPtrTo<I::Window_Input> mp_input;
    Wnd_Main *mp_wnd_main;
 
    VariantNode m_varUserData;
@@ -122,10 +125,10 @@ private:
    Collection<CntPtrTo<SpawnTabs>> m_spawn_tabs;
 };
 
-struct Windows : Dispatch<IWindows>
+struct Windows : Dispatch<I::Windows>
 {
    // IWindows
-   STDMETHODIMP get_Item(VARIANT var, IWindow_Main **retval);
+   STDMETHODIMP get_Item(VARIANT var, I::Window_Main **retval);
    STDMETHODIMP get_Count(long *retval);
 };
 

--- a/src/Wnd_Taskbar.cpp
+++ b/src/Wnd_Taskbar.cpp
@@ -122,9 +122,13 @@ Color Wnd_Taskbar::DrawWindow(RectF rcWindow, Wnd_Main &wnd, unsigned tabNumber)
    // Draw logging indicator
    if(connection.IsLogging() && g_ppropGlobal->fTaskbarShowLogging())
    {
-      float width=mp_font_emoji->Measure("●", m_font_size);
+      FixedStringBuilder<16> string("●");
+      if((connection.GetAutoLog()!=nullptr) + connection.GetLogs().Count()>1)
+         string("⁺");
+
+      float width=mp_font_emoji->Measure(string, m_font_size);
       mp_brush_dynamic->SetColor(ToD2D(Color(225,0,0)));
-      mp_font_emoji->Draw("●", m_font_size, rcText.ptLT()+float2(0, emoji_top), *mp_render_target, *mp_brush_dynamic);
+      mp_font_emoji->Draw(string, m_font_size, rcText.ptLT()+float2(0, emoji_top), *mp_render_target, *mp_brush_dynamic);
       rcText.left+=width+1;
    }
 

--- a/src/Wnd_Text_OM.cpp
+++ b/src/Wnd_Text_OM.cpp
@@ -28,7 +28,7 @@ HRESULT TextWindowLine::get_HTMLString(BSTR *retval)
    return S_OK;
 }
 
-HRESULT TextWindowLine::Insert(unsigned iPosition, ITextWindowLine *pILine)
+HRESULT TextWindowLine::Insert(unsigned iPosition, I::TextWindowLine *pILine)
 {
    const TextWindowLine *pLine=static_cast<TextWindowLine *>(pILine);
    if(pLine==this)
@@ -105,7 +105,7 @@ Window_Text::~Window_Text()
       delete m_pWnd;
 }
 
-STDMETHODIMP Window_Text::get_Properties(IWindow_Properties **retval)
+STDMETHODIMP Window_Text::get_Properties(I::Window_Properties **retval)
 {
    ZOMBIECHECK
    return RefReturner(retval)(MakeCounting<Window_Properties>(*m_pWnd, *m_pWnd));
@@ -136,7 +136,7 @@ STDMETHODIMP Window_Text::WriteHTML(BSTR bstr)
    return S_OK;
 }
 
-STDMETHODIMP Window_Text::Create(BSTR bstr, ITextWindowLine **ppLine)
+STDMETHODIMP Window_Text::Create(BSTR bstr, I::TextWindowLine **ppLine)
 {
    ZOMBIECHECK
    *ppLine=new TextWindowLine(BSTRToLStr(bstr), false);
@@ -144,7 +144,7 @@ STDMETHODIMP Window_Text::Create(BSTR bstr, ITextWindowLine **ppLine)
    return S_OK;
 }
 
-STDMETHODIMP Window_Text::CreateHTML(BSTR bstr, ITextWindowLine **ppLine)
+STDMETHODIMP Window_Text::CreateHTML(BSTR bstr, I::TextWindowLine **ppLine)
 {
    ZOMBIECHECK
    *ppLine=new TextWindowLine(BSTRToLStr(bstr), true);
@@ -152,7 +152,7 @@ STDMETHODIMP Window_Text::CreateHTML(BSTR bstr, ITextWindowLine **ppLine)
    return S_OK;
 }
 
-STDMETHODIMP Window_Text::Add(ITextWindowLine *pILine)
+STDMETHODIMP Window_Text::Add(I::TextWindowLine *pILine)
 {
    ZOMBIECHECK
    m_pWnd->Add(MakeUnique<Text::Line>(static_cast<TextWindowLine *>(pILine)->GetInternal()));

--- a/src/Wnd_Text_OM.h
+++ b/src/Wnd_Text_OM.h
@@ -3,7 +3,7 @@
 namespace OM
 {
 
-struct TextWindowLine : Dispatch<ITextWindowLine>
+struct TextWindowLine : Dispatch<I::TextWindowLine>
 {
    TextWindowLine(ConstString string, bool fHTML) : mp_line(Text::Line::CreateFromHTML(string))
    {
@@ -22,7 +22,7 @@ struct TextWindowLine : Dispatch<ITextWindowLine>
    STDMETHODIMP get_String(BSTR *retval) override;
    STDMETHODIMP get_HTMLString(BSTR *retval) override;
 
-   STDMETHODIMP Insert(unsigned position, ITextWindowLine *pLine) override;
+   STDMETHODIMP Insert(unsigned position, I::TextWindowLine *pLine) override;
    STDMETHODIMP Delete(unsigned start, unsigned end) override;
 
    STDMETHODIMP Color(unsigned start, unsigned end, long lColor) override;
@@ -43,7 +43,7 @@ private:
 };
 
 struct Window_Text
-:  Dispatch<IWindow_Text>,
+:  Dispatch<I::Window_Text>,
    Text::IHost,
    Events::ReceiversOf<Window_Text, Text::Wnd::Event_Pause>
 {
@@ -63,21 +63,21 @@ struct Window_Text
 
    ~Window_Text() noexcept;
 
-   USE_INHERITED_UNKNOWN(IWindow_Text)
+   USE_INHERITED_UNKNOWN(I::Window_Text)
 
    // IUnknown
    STDMETHODIMP QueryInterface(REFIID riid, void **ppvObj) override;
 
    // ITextWindow methods
-   STDMETHODIMP get_Properties(IWindow_Properties **retval) override;
+   STDMETHODIMP get_Properties(I::Window_Properties **retval) override;
    STDMETHODIMP get_Paused(VARIANT_BOOL *retval) override;
 
    STDMETHODIMP SetOnPause(IDispatch *pDisp) override;
    STDMETHODIMP Write(BSTR bstr) override;
    STDMETHODIMP WriteHTML(BSTR bstr) override;
-   STDMETHODIMP Create(BSTR bstr, ITextWindowLine **ppLine) override;
-   STDMETHODIMP CreateHTML(BSTR bstr, ITextWindowLine **ppLine) override;
-   STDMETHODIMP Add(ITextWindowLine *pLine) override;
+   STDMETHODIMP Create(BSTR bstr, I::TextWindowLine **ppLine) override;
+   STDMETHODIMP CreateHTML(BSTR bstr, I::TextWindowLine **ppLine) override;
+   STDMETHODIMP Add(I::TextWindowLine *pLine) override;
 
    // Events
    void On(const Text::Wnd::Event_Pause &event);


### PR DESCRIPTION
See Assets/Changes.txt for user visible changes

Internal Changes:

* Rename all OM types from 'IInterface' to 'I::Interface' to avoid I prefix in all of the type names, yet keep them separate from the built in native types.
* Redid regex capture so that there are now two digit capture indices for crazy regex folks. Previously there was \# and now there's \a## for two digit indices.